### PR TITLE
Add layerwise calibration observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Router-weighted Expert Activation Pruning (REAP)
 
 ## Updates
+* 2026-03-30: We have added a memory-efficient layer-wise (block-wise) calibration observer for pruning large models on a single GPU (see `experiments/pruning-layerwise-cli.sh` on how to run layer-wise calibration).
 * 2026-03-19: We have released our data calibration mix recipe for agentic reasoning REAP-compressed models published on HuggingFace (see [details](#huggingface-checkpoints)).
 * 2026-03-11: For REAP saliency, top-k router logits are now correctly renormalized to sum to 1. See `args.py:ObserverArgs.renormalize_router_weights`. Generally, you can expect a modest improvement for most model/datasets with this fix in place. On non-agentic coding evaluations across ERNIE-4.5-21B-A3B-PT, Qwen3-30B-A3B, Mixtral-8x7B-Instruct-v0.1, GLM-4.5-Air,and Llama-4-Scout-17B-16E-Instruct, REAP achieves a mean decrease in accuracy of 1.9% vs. 2.6% without logit normalization. Our prior large-scale results and all Cerebras checkpoints on previously calibrated with normalized logits. 
 * 2026-03-01: REAP has been accepted to ICLR 2026, see you in Rio! 

--- a/experiments/pruning-layerwise-cli.sh
+++ b/experiments/pruning-layerwise-cli.sh
@@ -10,17 +10,16 @@ compression_ratio=${5:-0.25}
 dataset_name=${6:-"theblackcat102/evol-codealpaca-v1"}
 
 artifact_dir_name() {
-    python - "$1" <<'PY'
-import hashlib
-import re
-import sys
+    local value=$1
+    local base hash
 
-value = sys.argv[1]
-if "," in value:
-    print(f"composite_{hashlib.md5(value.encode()).hexdigest()[:8]}")
-else:
-    print(re.sub(r"[^\w\-_.]", "_", value.split("/")[-1]))
-PY
+    if [[ $value == *,* ]]; then
+        hash=$(printf '%s' "$value" | md5sum)
+        printf 'composite_%.8s\n' "$hash"
+    else
+        base=${value##*/}
+        printf '%s\n' "${base//[^[:alnum:]_.-]/_}"
+    fi
 }
 
 # qa
@@ -88,6 +87,3 @@ bash experiments/eval.sh \
     ${run_math} \
     ${run_wildbench}
 echo "Finished evaluating model: ${model_dir}"
-
-# echo "Removing safetensor files from ${model_dir}"
-# rm ${model_dir}/*.safetensors

--- a/experiments/pruning-layerwise-cli.sh
+++ b/experiments/pruning-layerwise-cli.sh
@@ -34,8 +34,8 @@ run_math=${10:-false}
 run_wildbench=${11:-false}
 singleton_super_experts=${12:-"false"}
 singleton_outlier_experts=${13:-"false"}
-batch_size=1
-num_batches=1024
+num_batches=128
+batch_size=8
 output_file_name="observations_${num_batches}_cosine-seed_${seed}.pt"
 
 
@@ -47,7 +47,7 @@ echo "Evaluations: lm_eval: $run_lm_eval, evalplus: $run_evalplus, livecodebench
 echo "Using seed: $seed"
 
 echo "Running with model: $model_name, dataset: $dataset_name, compression ratio: $compression_ratio, pruning method: $pruning_method"
-python src/reap/prune.py \
+python -m reap.layerwise_prune \
     --model-name $model_name \
     --dataset-name $dataset_name \
     --compression-ratio $compression_ratio \
@@ -56,24 +56,22 @@ python src/reap/prune.py \
     --vllm_port $port \
     --server-log-file-name $server_log_file_name \
     --do-eval false \
-    --distance_measure cosine \
     --seed $seed \
     --output_file_name ${output_file_name} \
-    --singleton_super_experts ${singleton_super_experts} \
-    --singleton_outlier_experts ${singleton_outlier_experts} \
-    --batch_size ${batch_size} \
     --batches_per_category ${num_batches} \
-    --record_pruning_metrics_only true
+    --batch_size ${batch_size} \
+    --low_cpu_mem_usage True
 
 short_model_name=$(artifact_dir_name "$model_name")
 short_dataset_name=$(artifact_dir_name "$dataset_name")
 
-pruned_model_dir_name="${pruning_method}"
+pruned_model_dir_name="layerwise_${pruning_method}"
 if [[ "${singleton_super_experts}" == "true" ]]; then
     pruned_model_dir_name="${pruned_model_dir_name}-perserve_super"
 elif [[ "${singleton_outlier_experts}" == "true" ]]; then
     pruned_model_dir_name="${pruned_model_dir_name}-perserve_outlier"
 fi
+pruned_model_dir_name="${pruned_model_dir_name}-renorm_true"
 pruned_model_dir_name="${pruned_model_dir_name}-seed_${seed}-${compression_ratio}"
 
 model_dir="artifacts/${short_model_name}/${short_dataset_name}/pruned_models/${pruned_model_dir_name}"
@@ -89,7 +87,7 @@ bash experiments/eval.sh \
     ${run_livecodebench} \
     ${run_math} \
     ${run_wildbench}
-echo "Finished evaluating model: ${pruned_model}"
+echo "Finished evaluating model: ${model_dir}"
 
 # echo "Removing safetensor files from ${model_dir}"
 # rm ${model_dir}/*.safetensors

--- a/src/reap/args.py
+++ b/src/reap/args.py
@@ -99,7 +99,7 @@ class DatasetArgs:
 
 @dataclass
 class ObserverArgs:
-    samples_per_category: int = 1024
+    batches_per_category: int = 1024
     split_by_category: bool = False
     select_only_categories: list[str] | str | None = field(
         default=None,
@@ -110,7 +110,7 @@ class ObserverArgs:
             )
         },
     )
-    batch_size: int = 1
+    batch_size: int = 8
     model_max_length: int | None = 2048
     return_vllm_tokens_prompt: bool = False
     truncate: bool = False
@@ -515,7 +515,7 @@ class PruneArgs:
         default=False,
         metadata={
             "help": (
-                r"Whether to perserve super experts when pruning. Excludes last 25% of layers"
+                r"Whether to perserve super experts when pruning. Excludes last 25%% of layers"
             )
         }
     )
@@ -528,6 +528,41 @@ class PruneArgs:
         }
     )
 
+
+@dataclass
+class LayerwiseArgs:
+    """Arguments for layerwise (memory-efficient) calibration."""
+
+    batch_group_size: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Number of pre-tokenized calibration batches to process at a time. "
+                "If set, the layerwise observer processes one group through all blocks "
+                "before moving to the next group, which reduces CPU RAM usage from "
+                "cached first-layer inputs."
+            )
+        },
+    )
+    save_intermediate: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to save intermediate results after each block during layerwise "
+                "calibration. Useful for debugging and recovery."
+            )
+        },
+    )
+    low_cpu_mem_usage: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Use memory-efficient model loading. Recommended for large models."
+            )
+        },
+    )
+
+    
 @dataclass
 class QuantizationArgs:
     quantization_method: str = field(

--- a/src/reap/args.py
+++ b/src/reap/args.py
@@ -515,7 +515,7 @@ class PruneArgs:
         default=False,
         metadata={
             "help": (
-                r"Whether to perserve super experts when pruning. Excludes last 25%% of layers"
+                "Whether to preserve super experts when pruning. Excludes last 25%% of layers"
             )
         }
     )
@@ -523,7 +523,7 @@ class PruneArgs:
         default=False,
         metadata={
             "help": (
-                "Whether to perserve outlier experts when pruning, includes all layers"
+                "Whether to preserve outlier experts when pruning, includes all layers"
             )
         }
     )
@@ -538,6 +538,7 @@ class LayerwiseArgs:
         metadata={
             "help": (
                 "Number of pre-tokenized calibration batches to process at a time. "
+                "If not set, process all the batches generated from the dataset. "
                 "If set, the layerwise observer processes one group through all blocks "
                 "before moving to the next group, which reduces CPU RAM usage from "
                 "cached first-layer inputs."

--- a/src/reap/data.py
+++ b/src/reap/data.py
@@ -60,6 +60,39 @@ def _normalize_message_content(content) -> str:
     return str(content)
 
 
+def _normalize_messages_for_chat_template(messages):
+    if not isinstance(messages, list):
+        return messages
+
+    normalized_messages = []
+    for message in messages:
+        if not isinstance(message, dict) or not message.get("tool_calls"):
+            normalized_messages.append(message)
+            continue
+
+        normalized_message = dict(message)
+        normalized_tool_calls = []
+        for tool_call in message["tool_calls"]:
+            if not isinstance(tool_call, dict) or not isinstance(
+                tool_call.get("function"), dict
+            ):
+                normalized_tool_calls.append(tool_call)
+                continue
+
+            normalized_tool_call = dict(tool_call)
+            normalized_function = dict(tool_call["function"])
+            normalized_function["arguments"] = _maybe_json_load(
+                normalized_function.get("arguments")
+            )
+            normalized_tool_call["function"] = normalized_function
+            normalized_tool_calls.append(normalized_tool_call)
+
+        normalized_message["tool_calls"] = normalized_tool_calls
+        normalized_messages.append(normalized_message)
+
+    return normalized_messages
+
+
 @dataclass
 class CompositeDatasetComponent:
     """A single component of a composite dataset specification.
@@ -70,26 +103,26 @@ class CompositeDatasetComponent:
                the default split from DatasetArgs.
         subset: HF dataset config/subset name (e.g., "code", "math"). None means
                 do not pass a subset to ``load_dataset``.
-        num_samples: Number of samples to draw from this component.
+        num_batches: Number of batches to draw from this component.
     """
 
     name: str
     split: str | None
     subset: str | None
-    num_samples: int
+    num_batches: int
 
 
-# Regex to parse a single component: <name>[<subset>](<split>):<num_samples>
+# Regex to parse a single component: <name>[<subset>](<split>):<num_batches>
 # Examples:
-#   "theblackcat102/evol-codealpaca-v1:4096"            -> name="theblackcat102/evol-codealpaca-v1", subset=None, split=None, num_samples=4096
-#   "open-r1/Mixture-of-Thoughts[code]:4096"            -> name="open-r1/Mixture-of-Thoughts", subset="code", split=None, num_samples=4096
-#   "SWE-bench/SWE-smith-trajectories(tool):4096"      -> name="SWE-bench/SWE-smith-trajectories", subset=None, split="tool", num_samples=4096
-#   "dataset[subset](split):4096"                      -> name="dataset", subset="subset", split="split", num_samples=4096
+#   "theblackcat102/evol-codealpaca-v1:4096"            -> name="theblackcat102/evol-codealpaca-v1", subset=None, split=None, num_batches=4096
+#   "open-r1/Mixture-of-Thoughts[code]:4096"            -> name="open-r1/Mixture-of-Thoughts", subset="code", split=None, num_batches=4096
+#   "SWE-bench/SWE-smith-trajectories(tool):4096"      -> name="SWE-bench/SWE-smith-trajectories", subset=None, split="tool", num_batches=4096
+#   "dataset[subset](split):4096"                      -> name="dataset", subset="subset", split="split", num_batches=4096
 _COMPOSITE_COMPONENT_RE = re.compile(
     r"^(?P<name>[^\[\]()[:,]+)"  # dataset name
     r"(?:\[(?P<subset>[^\]]+)\])?"  # optional [subset]
     r"(?:\((?P<split>[^\)]+)\))?"  # optional (split)
-    r":(?P<num_samples>\d+)$"  # :num_samples (required for composite)
+    r":(?P<num_batches>\d+)$"  # :num_batches (required for composite)
 )
 
 
@@ -101,7 +134,7 @@ def parse_composite_dataset_spec(
     """Parse a composite dataset specification string.
 
     Returns a list of CompositeDatasetComponent if the spec is composite
-    (contains comma-separated entries with :num_samples), or None if the spec
+    (contains comma-separated entries with :num_batches), or None if the spec
     is a single dataset name (backward-compatible).
 
     Format: ``name1[subset1](split1):N1,name2:N2,name3[subset3]:N3,...``
@@ -137,7 +170,7 @@ def parse_composite_dataset_spec(
                 return None
             raise ValueError(
                 f"Failed to parse composite dataset component {i}: '{part}'. "
-                f"Expected format: <dataset_name>[<subset>](<split>):<num_samples>. "
+                f"Expected format: <dataset_name>[<subset>](<split>):<num_batches>. "
                 f"Full spec: '{spec}'"
             )
         name = m.group("name").strip()
@@ -147,13 +180,13 @@ def parse_composite_dataset_spec(
         split = m.group("split")
         if split is None:
             split = default_split
-        num_samples = int(m.group("num_samples"))
+        num_batches = int(m.group("num_batches"))
         components.append(
             CompositeDatasetComponent(
                 name=name,
                 split=split,
                 subset=subset,
-                num_samples=num_samples,
+                num_batches=num_batches,
             )
         )
 
@@ -166,7 +199,7 @@ def parse_composite_dataset_spec(
             f"{c.name}"
             f"{f'[{c.subset}]' if c.subset is not None else ''}"
             f"{f'({c.split})' if c.split is not None else ''}"
-            f":{c.num_samples}"
+            f":{c.num_batches}"
             for c in components
         )
     )
@@ -202,7 +235,7 @@ def load_category_batches(
     split_by_category,
     return_vllm_tokens_prompt,
     truncate,
-    samples_per_category,
+    batches_per_category,
 ):
     raw_ds = _load_raw_dataset(dataset_name, split, subset=subset)
 
@@ -226,7 +259,7 @@ def load_category_batches(
         batch_size=batch_size,
     )
     category_data_batches = processor.get_processed_dataset(
-        samples_per_category=samples_per_category,
+        batches_per_category=batches_per_category,
     )
     return category_data_batches
 
@@ -337,7 +370,7 @@ class BaseDatasetProcessor(ABC):
         )
 
     def get_processed_dataset(
-        self, samples_per_category: int
+        self, batches_per_category: int
     ) -> dict[str, list[TokensPrompt]] | dict[str, list[BatchEncoding]]:
         """Get requests for each category in the dataset."""
         if self._mapped_dataset is None:
@@ -349,13 +382,13 @@ class BaseDatasetProcessor(ABC):
                 else self.select_only_categories
             )
             return {
-                c: self._process_samples_for_category(c, samples_per_category)
+                c: self._process_samples_for_category(c, batches_per_category)
                 for c in categories
             }
         else:
             return {
                 self.all_categories_label: self._process_samples_for_category(
-                    self.all_categories_label, samples_per_category
+                    self.all_categories_label, batches_per_category
                 ),
             }
 
@@ -371,7 +404,7 @@ class BaseDatasetProcessor(ABC):
     def _process_samples_for_category(
         self,
         category: str,
-        samples_per_category: int,
+        batches_per_category: int,
     ) -> list[TokensPrompt] | list[BatchEncoding]:
         if category != self.all_categories_label:
             category_dataset = self._mapped_dataset.filter(
@@ -383,11 +416,11 @@ class BaseDatasetProcessor(ABC):
 
         if self.pack_samples:
             return self._process_samples_for_category_packed(
-                category, samples_per_category, category_dataset
+                category, batches_per_category, category_dataset
             )
         else:
             return self._process_samples_for_category_unpacked(
-                category, samples_per_category, category_dataset
+                category, batches_per_category, category_dataset
             )
 
     def _collate_batch(self, batch: list[dict[str, torch.Tensor]]) -> BatchEncoding:
@@ -445,17 +478,17 @@ class BaseDatasetProcessor(ABC):
     def _process_samples_for_category_unpacked(
         self,
         category: str,
-        samples_per_category: int,
+        batches_per_category: int,
         category_dataset: Dataset,
     ) -> list[TokensPrompt] | list[BatchEncoding]:
         processed_samples = []
         sampled = []  # sample without replacement
         current_batch = []
-        while len(processed_samples) < samples_per_category:
+        while len(processed_samples) < batches_per_category:
             if len(sampled) >= len(category_dataset):
                 logger.warning(
                     f"Not enough samples in category '{category}' to reach "
-                    f"{samples_per_category} samples. Only {len(sampled)} "
+                    f"{batches_per_category} data batches. Only {len(sampled)} "
                     "samples were processed.",
                 )
                 break
@@ -496,17 +529,17 @@ class BaseDatasetProcessor(ABC):
     def _process_samples_for_category_packed(
         self,
         category: str,
-        samples_per_category: int,
+        batches_per_category: int,
         category_dataset: Dataset,
     ) -> list[TokensPrompt] | list[BatchEncoding]:
         processed_samples = []
         sampled = []
         current_batch = []
-        while len(processed_samples) < samples_per_category:
+        while len(processed_samples) < batches_per_category:
             if len(sampled) >= len(category_dataset):
                 logger.warning(
                     f"Not enough samples in category '{category}' to reach "
-                    f"{samples_per_category} samples. Only {len(sampled)} "
+                    f"{batches_per_category} data batches. Only {len(sampled)} "
                     "samples were processed.",
                 )
                 break
@@ -557,10 +590,11 @@ class BaseDatasetProcessor(ABC):
 class ChatDatasetProcessor(BaseDatasetProcessor):
     def _encode_sample(self, sample: dict) -> torch.Tensor:
         chat_template_kwargs = {}
+        messages = _normalize_messages_for_chat_template(sample[self.messages_field])
         if self.tools_field in sample:
             chat_template_kwargs = {"tools": _maybe_json_load(sample[self.tools_field])}
         chat_sample = self.tokenizer.apply_chat_template(
-            sample[self.messages_field],
+            messages,
             add_generation_prompt=False,
             tokenize=False,
             **chat_template_kwargs,
@@ -578,12 +612,15 @@ class ChatDatasetProcessor(BaseDatasetProcessor):
         def chat_template_fn(sample: dict[str, any]) -> dict[str, any]:
             """Apply chat template to the sample."""
             chat_template_kwargs = {}
+            messages = _normalize_messages_for_chat_template(
+                sample[self.messages_field]
+            )
             if self.tools_field in sample:
                 chat_template_kwargs = {
                     "tools": _maybe_json_load(sample[self.tools_field])
                 }
             chat_sample = self.tokenizer.apply_chat_template(
-                sample[self.messages_field],
+                messages,
                 add_generation_prompt=False,
                 tokenize=False,
                 **chat_template_kwargs,

--- a/src/reap/data.py
+++ b/src/reap/data.py
@@ -382,12 +382,12 @@ class BaseDatasetProcessor(ABC):
                 else self.select_only_categories
             )
             return {
-                c: self._process_samples_for_category(c, batches_per_category)
+                c: self._process_batches_for_category(c, batches_per_category)
                 for c in categories
             }
         else:
             return {
-                self.all_categories_label: self._process_samples_for_category(
+                self.all_categories_label: self._process_batches_for_category(
                     self.all_categories_label, batches_per_category
                 ),
             }
@@ -401,7 +401,7 @@ class BaseDatasetProcessor(ABC):
             return ["all"]
         return self.dataset.unique(self.category_field)
 
-    def _process_samples_for_category(
+    def _process_batches_for_category(
         self,
         category: str,
         batches_per_category: int,
@@ -415,11 +415,11 @@ class BaseDatasetProcessor(ABC):
             category = self.all_categories_label
 
         if self.pack_samples:
-            return self._process_samples_for_category_packed(
+            return self._process_batches_for_category_packed(
                 category, batches_per_category, category_dataset
             )
         else:
-            return self._process_samples_for_category_unpacked(
+            return self._process_batches_for_category_unpacked(
                 category, batches_per_category, category_dataset
             )
 
@@ -475,7 +475,7 @@ class BaseDatasetProcessor(ABC):
             }
         )
 
-    def _process_samples_for_category_unpacked(
+    def _process_batches_for_category_unpacked(
         self,
         category: str,
         batches_per_category: int,
@@ -526,7 +526,7 @@ class BaseDatasetProcessor(ABC):
 
         return processed_samples
 
-    def _process_samples_for_category_packed(
+    def _process_batches_for_category_packed(
         self,
         category: str,
         batches_per_category: int,

--- a/src/reap/layerwise_model_utils.py
+++ b/src/reap/layerwise_model_utils.py
@@ -1,0 +1,307 @@
+"""
+Model utilities for layerwise processing of MoE models.
+
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, List, Tuple, Union, Optional
+import gc
+import logging
+
+import torch
+import torch.nn as nn
+from itertools import chain
+
+logger = logging.getLogger(__name__)
+
+
+NATURAL_SORT_RE = re.compile(r"(\d+)")
+
+LINEAR_PARAM_NAMES = frozenset(
+    {
+        "weight",
+        "w1",
+        "w2",
+        "w3",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+        "gate_up_proj",
+        "expert_weight",
+    }
+)
+
+LINEAR_CLASS_HINTS = ("expert", "mlp", "ffn", "feedforward")
+
+DECODER_BLOCK_PATTERNS = (
+    re.compile(r"\.layers\.\d+$"),
+    re.compile(r"\.decoder\.layers\.\d+$"),
+    re.compile(r"\.transformer\.h\.\d+$"),
+    re.compile(r"\.transformer\.layers\.\d+$"),
+    re.compile(r"\.decoder\.block\.\d+$"),
+)
+
+NON_BACKBONE_PATTERNS = (
+    "embed_tokens",
+    "wte",
+    "word_embeddings",
+    "embeddings.word_embeddings",
+    "embed_positions",
+    "wpe",
+    "position_embeddings",
+    "norm",
+    "ln_f",
+    "final_layer_norm",
+    "layer_norm",
+    "lm_head",
+    "embed_out",
+    "output_projection",
+)
+
+
+def _iter_module_tensors(module: nn.Module):
+    """Yield all parameters and buffers from a module."""
+    yield from module.parameters()
+    yield from module.buffers()
+
+
+def safe_get_device(module: nn.Module) -> str:
+    """Safely get the first non-meta device of a module."""
+    try:
+        for tensor in _iter_module_tensors(module):
+            device_str = str(tensor.device)
+            if device_str != "meta":
+                return device_str
+        return "meta"
+    except Exception:
+        raise
+
+
+def has_meta_tensors(module: nn.Module) -> bool:
+    """Check whether a module contains any meta tensors."""
+    try:
+        return any(str(tensor.device) == "meta" for tensor in _iter_module_tensors(module))
+    except Exception:
+        return False
+
+
+def natural_sort_key(value: str) -> tuple[object, ...]:
+    """Return a key that sorts strings with embedded numbers naturally.
+
+    Example:
+        "file2" < "file10"
+    """
+    return tuple(
+        int(part) if part.isdigit() else part.lower()
+        for part in NATURAL_SORT_RE.split(value)
+    )
+
+
+def cleanup_memory(synchronize: bool = True) -> None:
+    """Run Python GC and release cached CUDA memory when available."""
+    gc.collect()
+
+    if not torch.cuda.is_available():
+        return
+
+    if synchronize:
+        torch.cuda.synchronize()
+
+    torch.cuda.empty_cache()
+
+
+def move_to_device(value: Any, target_device: torch.device) -> Any:
+    """Recursively move tensors within nested structures to target device."""
+    if torch.is_tensor(value) and str(value.device) != "meta":
+        return value.to(target_device)
+    if isinstance(value, dict):
+        return {k: move_to_device(v, target_device) for k, v in value.items()}
+    if isinstance(value, (tuple, list)):
+        moved = [move_to_device(v, target_device) for v in value]
+        return type(value)(moved)
+    return value
+
+
+def is_linear_like(module: nn.Module) -> bool:
+    """
+    Heuristically detect modules that behave like linear projections.
+    """
+    if isinstance(module, nn.Embedding):
+        return False
+
+    if isinstance(module, nn.Linear):
+        return True
+
+    if _is_pointwise_conv1d(module):
+        return True
+
+    return _has_linear_like_local_weights(module)
+
+
+def _is_pointwise_conv1d(module: nn.Module) -> bool:
+    """Return True for 1x1 Conv1d layers used as projections."""
+    return isinstance(module, nn.Conv1d) and module.kernel_size == (1,)
+
+
+def _has_linear_like_local_weights(module: nn.Module) -> bool:
+    """
+    Heuristic for custom modules that expose 2D local parameters
+    resembling projection weights.
+    """
+    local_2d_param_names = {
+        name
+        for name, param in module.named_parameters(recurse=False)
+        if param is not None and getattr(param, "ndim", None) == 2
+    }
+
+    if not local_2d_param_names:
+        return False
+
+    if local_2d_param_names & LINEAR_PARAM_NAMES:
+        return True
+
+    class_name = module.__class__.__name__.casefold()
+    return any(hint in class_name for hint in LINEAR_CLASS_HINTS)
+
+
+def _matches_decoder_block_name(name: str) -> bool:
+    return any(pattern.search(name) for pattern in DECODER_BLOCK_PATTERNS)
+
+
+def _has_projection_like_child(module: nn.Module) -> bool:
+    return any(is_linear_like(child) for child in module.modules())
+
+
+def is_decoder_block(name: str, module: nn.Module) -> bool:
+    """
+    Return True if the module looks like a transformer decoder block.
+    """
+    return _matches_decoder_block_name(name) and _has_projection_like_child(module)
+
+
+def get_module_by_name(model: nn.Module, module_name: str) -> Optional[nn.Module]:
+    module = model
+
+    for part in module_name.split("."):
+        if hasattr(module, part):
+            module = getattr(module, part)
+        elif part.isdigit() and hasattr(module, "__getitem__"):
+            try:
+                module = module[int(part)]
+            except (IndexError, TypeError):
+                return None
+        else:
+            return None
+
+    return module
+
+
+def _is_same_or_child(name: str, parent: str) -> bool:
+    """Return True if `name` is `parent` or a descendant of it."""
+    return name == parent or name.startswith(f"{parent}.")
+
+
+def _is_non_empty_container(module: nn.Module) -> bool:
+    """Best-effort check for ModuleList/Sequential-like containers."""
+    try:
+        return len(module) > 0  # type: ignore[arg-type]
+    except TypeError:
+        return False
+
+
+def _find_blocks_container(
+    modules_by_name: Dict[str, nn.Module],
+    block_names: Sequence[str],
+) -> Union[nn.Module, None]:
+    """
+    If all blocks share the same direct parent, use that as the container.
+    Example:
+        transformer.h.0, transformer.h.1 -> transformer.h
+    """
+    parent_names = {
+        block_name.rsplit(".", 1)[0]
+        for block_name in block_names
+        if "." in block_name
+    }
+
+    if len(parent_names) != 1:
+        return None
+
+    container_name = next(iter(parent_names))
+    container = modules_by_name.get(container_name)
+
+    if container is not None and _is_non_empty_container(container):
+        logger.info(
+            "Found transformer blocks container: %s with %d blocks",
+            container_name,
+            len(container),
+        )
+        return container
+
+    return None
+
+
+def _find_non_backbone_modules(
+    module_names: Sequence[str],
+    block_names: Sequence[str],
+) -> List[str]:
+    block_name_set = set(block_names)
+    block_prefixes = tuple(f"{name}." for name in block_names)
+
+    non_backbone_modules: List[str] = []
+
+    for name in module_names:
+        # Skip transformer blocks and anything nested inside them.
+        if name in block_name_set or name.startswith(block_prefixes):
+            continue
+
+        # Prefer exact/suffix matching over raw substring matching.
+        if any(name == pattern or name.endswith(f".{pattern}") for pattern in NON_BACKBONE_PATTERNS):
+            non_backbone_modules.append(name)
+            logger.debug("Found non-backbone module: %s", name)
+
+    return non_backbone_modules
+
+
+def extract_model_components(
+    model: nn.Module,
+    block_names: List[str],
+):
+    """
+    Extract and cache essential model components for selective loading.
+
+    Returns:
+        (blocks, non_backbone_modules)
+    """
+    if not block_names:
+        raise ValueError("block_names must not be empty")
+
+    logger.info("Extracting model components...")
+
+    modules_by_name = dict(model.named_modules())
+
+    blocks = _find_blocks_container(modules_by_name, block_names)
+    if blocks is None:
+        blocks = [modules_by_name[name] for name in block_names if name in modules_by_name]
+        logger.info("Collected %d individual transformer blocks", len(blocks))
+
+    non_backbone_modules = _find_non_backbone_modules(
+        list(modules_by_name.keys()),
+        block_names,
+    )
+
+    return blocks, non_backbone_modules
+
+
+def find_decoder_blocks(model: nn.Module) -> List[str]:
+    """Detect decoder blocks in the model."""
+    modules = list(model.named_modules())
+
+    block_names = [name for name, module in modules if is_decoder_block(name, module)]
+    if block_names:
+        return sorted(block_names, key=natural_sort_key)
+
+    raise RuntimeError(
+        "No decoder blocks detected in the model."
+    )

--- a/src/reap/layerwise_model_utils.py
+++ b/src/reap/layerwise_model_utils.py
@@ -68,23 +68,17 @@ def _iter_module_tensors(module: nn.Module):
 
 def safe_get_device(module: nn.Module) -> str:
     """Safely get the first non-meta device of a module."""
-    try:
-        for tensor in _iter_module_tensors(module):
-            device_str = str(tensor.device)
-            if device_str != "meta":
-                return device_str
-        return "meta"
-    except Exception:
-        raise
-
+    for tensor in _iter_module_tensors(module):
+        device_str = str(tensor.device)
+        if device_str != "meta":
+            return device_str
+    return "meta"
+    
 
 def has_meta_tensors(module: nn.Module) -> bool:
     """Check whether a module contains any meta tensors."""
-    try:
-        return any(str(tensor.device) == "meta" for tensor in _iter_module_tensors(module))
-    except Exception:
-        return False
-
+    return any(str(tensor.device) == "meta" for tensor in _iter_module_tensors(module))
+    
 
 def natural_sort_key(value: str) -> tuple[object, ...]:
     """Return a key that sorts strings with embedded numbers naturally.
@@ -169,7 +163,7 @@ def _matches_decoder_block_name(name: str) -> bool:
     return any(pattern.search(name) for pattern in DECODER_BLOCK_PATTERNS)
 
 
-def _has_projection_like_child(module: nn.Module) -> bool:
+def _has_linear_like_child(module: nn.Module) -> bool:
     return any(is_linear_like(child) for child in module.modules())
 
 
@@ -177,7 +171,7 @@ def is_decoder_block(name: str, module: nn.Module) -> bool:
     """
     Return True if the module looks like a transformer decoder block.
     """
-    return _matches_decoder_block_name(name) and _has_projection_like_child(module)
+    return _matches_decoder_block_name(name) and _has_linear_like_child(module)
 
 
 def get_module_by_name(model: nn.Module, module_name: str) -> Optional[nn.Module]:

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -637,6 +637,7 @@ class LayerwiseMoEObserver:
         # Compute activations for all experts
         activations = torch.zeros((num_experts, *flat_input.shape), device=device)
 
+        # TODO(ivanl): model-specific handling of router_module return signature
         def extract_router_logits(router_module, input):
             """Call routers that expect either flattened or sequence-shaped hidden states.
 

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -415,8 +415,54 @@ class LayerwiseMoEObserver:
 
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
+        entry_signature = inspect.signature(entry_block.forward)
+        entry_param_names = [
+            name
+            for name, parameter in entry_signature.parameters.items()
+            if name != "self"
+            and parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+
         def intercept_entry_inputs(_, args, kwargs):
+            """Capture first-block inputs without assuming masks only arrive in kwargs.
+
+            ERNIE-style decoder layers may pass `attention_mask` and `position_ids`
+            positionally alongside non-tensor arguments, so we recover them by the
+            entry block's parameter names and only cache `hidden_states` as replay input.
+            """
             replay_kwargs = {}
+            attention_mask = kwargs.get("attention_mask")
+            position_ids = kwargs.get("position_ids")
+
+            replay_inputs: List[torch.Tensor] = []
+            for index, value in enumerate(args):
+                param_name = (
+                    entry_param_names[index] if index < len(entry_param_names) else None
+                )
+
+                if index == 0 or param_name == "hidden_states":
+                    if not torch.is_tensor(value):
+                        raise TypeError(
+                            "Expected first decoder block input hidden_states to be a tensor"
+                        )
+                    replay_inputs.append(value.detach().cpu())
+                    continue
+
+                if param_name == "attention_mask":
+                    attention_mask = value
+                    continue
+
+                if param_name == "position_ids":
+                    position_ids = value
+                    continue
+
+                if param_name is not None:
+                    replay_kwargs[param_name] = move_to_device(value, cpu_device)
+
             for key, value in kwargs.items():
                 if key in {"hidden_states", "attention_mask", "position_ids"}:
                     continue
@@ -424,15 +470,15 @@ class LayerwiseMoEObserver:
 
             captured_batches.append(
                 ReplayBatch(
-                    inputs=[tensor.detach().cpu() for tensor in args],
+                    inputs=replay_inputs,
                     kwargs=LayerwiseMoEObserver._sanitize_cached_block_kwargs(
                         replay_kwargs
                     ),
-                    attention_mask=kwargs["attention_mask"].detach().cpu()
-                    if kwargs.get("attention_mask") is not None
+                    attention_mask=attention_mask.detach().cpu()
+                    if torch.is_tensor(attention_mask)
                     else None,
-                    position_ids=kwargs["position_ids"].detach().cpu()
-                    if kwargs.get("position_ids") is not None
+                    position_ids=position_ids.detach().cpu()
+                    if torch.is_tensor(position_ids)
                     else None,
                 )
             )
@@ -592,7 +638,20 @@ class LayerwiseMoEObserver:
         activations = torch.zeros((num_experts, *flat_input.shape), device=device)
 
         def extract_router_logits(router_module, input):
-            result = router_module(input)
+            """Call routers that expect either flattened or sequence-shaped hidden states.
+
+            DeepSeek's gate unpacks `[batch, seq, hidden]` internally, while other
+            routers accept the flattened `[tokens, hidden]` view used for metric
+            collection. Retry with the original 3D shape when the flat call fails.
+            """
+            try:
+                result = router_module(input)
+            except (TypeError, ValueError):
+                if input.ndim != 2:
+                    raise
+                result = router_module(
+                    input.view(batch_size, sequence_length, hidden_dim)
+                )
             if isinstance(result, tuple):
                 *_, router_logits = result
             else:

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -1,0 +1,959 @@
+"""
+Layerwise MoE Observer for memory-efficient expert pruning calibration.
+
+This module implements a block-wise activation collection approach inspired by AutoGPTQ,
+adapted for MoE expert pruning metrics (REAP, EAN, frequency, etc.).
+
+Key features:
+1. Only one transformer block is loaded on GPU at a time
+2. Hidden states are cached between blocks (passed from block N to block N+1)
+3. Streaming approach - batches are processed one at a time
+4. Progressive loading/offloading of transformer blocks
+5. Computes all REAP pruning metrics per block
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+import gc
+import inspect
+import logging
+import pathlib
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.tokenization_utils_base import BatchEncoding
+
+from reap.observer import (
+    MoETransformerObserverConfig,
+)
+from reap.layerwise_model_utils import (
+    extract_model_components,
+    get_module_by_name,
+    find_decoder_blocks,
+    cleanup_memory,
+    move_to_device,
+    safe_get_device,
+    has_meta_tensors,
+)
+from reap.pruning_metrics import initialize_pruning_state, update_pruning_state
+from reap.metrics import OnlineStatsTracker
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class _FirstblockInputCaptured(Exception):
+    """Internal sentinel used to stop execution after caching block-0 inputs."""
+
+
+@dataclass
+class ReplayBatch:
+    """Cached replay payload for one calibration batch."""
+
+    inputs: List[torch.Tensor]
+    kwargs: Dict[str, Any]
+    attention_mask: Optional[torch.Tensor] = None
+    position_ids: Optional[torch.Tensor] = None
+
+
+class ReplayCache:
+    """Manage cached replay payloads between layerwise block forwards."""
+
+    def __init__(self) -> None:
+        self._batches: List[ReplayBatch] = []
+
+    def __len__(self) -> int:
+        return len(self._batches)
+
+    def append(
+        self,
+        inputs: List[torch.Tensor],
+        kwargs: Dict[str, Any],
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> None:
+        self._batches.append(
+            ReplayBatch(
+                inputs=inputs,
+                kwargs=kwargs,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+            )
+        )
+
+    def clear(self) -> None:
+        self._batches.clear()
+
+    def materialize(
+        self,
+        batch_idx: int,
+        target_device: torch.device,
+    ) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
+        batch = self._batches[batch_idx]
+
+        replay_inputs = [
+            tensor if str(tensor.device) == "meta" else tensor.to(target_device)
+            for tensor in batch.inputs
+        ]
+
+        replay_kwargs = {
+            key: move_to_device(value, target_device)
+            for key, value in batch.kwargs.items()
+        }
+
+        if batch.attention_mask is not None:
+            replay_kwargs["attention_mask"] = move_to_device(
+                batch.attention_mask, target_device
+            )
+        if batch.position_ids is not None:
+            replay_kwargs["position_ids"] = move_to_device(
+                batch.position_ids, target_device
+            )
+
+        return replay_inputs, replay_kwargs
+
+    def replace_inputs(self, next_inputs: List[List[torch.Tensor]]) -> None:
+        if len(next_inputs) != len(self._batches):
+            raise ValueError(
+                "Replacement inputs must match the replay cache batch count"
+            )
+
+        for batch, inputs in zip(self._batches, next_inputs):
+            batch.inputs = inputs
+
+
+class LayerwiseMoEObserver:
+    """
+    Memory-efficient MoE observer that processes one transformer block at a time.
+
+    This class collects the same pruning metrics as MoETransformerObserver but
+    in a memory-efficient manner suitable for large models on single GPUs.
+
+    Metrics collected per block:
+    - total_tokens: Total number of tokens processed
+    - expert_frequency: How often each expert is selected
+    - pairwise_expert_frequency: Co-occurrence counts
+    - ean_sum: Sum of L2 norms of expert outputs (for routed tokens)
+    - ean_mean: Mean of L2 norms
+    - weighted_ean_sum: Router-weighted EAN
+    - reap: Mean of (router_weight * activation_norm)
+    - weighted_expert_frequency_sum: Sum of router weights per expert
+    - max_activations: Maximum activation magnitude per expert
+    """
+
+    _REPLAY_KWARG_DROP_KEYS = {"past_key_value", "past_key_values"}
+    _REPLAY_KWARG_FORCED_VALUES = {
+        "use_cache": False,
+        "output_attentions": False,
+        "output_hidden_states": False,
+        "return_dict": False,
+        "output_router_loss": False,
+        "output_gate_logits": False,
+    }
+
+    def __init__(
+        self,
+        model: nn.Module,
+        hook_config: MoETransformerObserverConfig,
+        block_names: Optional[List[str]] = None,
+    ):
+        """
+        Initialize the layerwise (blockwise) MoE observer.
+
+        Args:
+            model: The PyTorch MoE model to observe
+            hook_config: Configuration for hooks (contains MoE-specific settings)
+            block_names: List of transformer block names. Auto-detected if None.
+        """
+        self.model = model
+        self.hook_config = hook_config
+        self._memory_cleanup_freq = 4
+
+        # Auto-detect decoder blocks if not provided
+        self.block_names = block_names or find_decoder_blocks(self.model)
+
+        # Extract model components
+        self.blocks, self.non_backbone_modules = extract_model_components(
+            self.model, self.block_names
+        )
+
+        # Cache for replaying block inputs and forward kwargs between blocks
+        self.replay_cache = ReplayCache()
+
+        # Track which block is currently loaded
+        self.currently_loaded_block_idx = -1
+
+        # Hooks for current block
+        self.hooks = []
+
+        # State dictionary to store metrics per block
+        self.state: Dict[int, Dict[str, Any]] = {}
+
+        # MoE module cache per block
+        self._moe_modules_cache: Dict[int, Optional[nn.Module]] = {}
+
+        # Forward signature cache per block
+        self._forward_signature_cache: Dict[int, Tuple[set[str], bool]] = {}
+
+        logger.info(
+            f"LayerwiseMoEObserver initialized with {len(self.block_names)} blocks"
+        )
+        logger.info(
+            f"Block names: {self.block_names[:3]}{'...' if len(self.block_names) > 3 else ''}"
+        )
+
+    def _find_moe_module_in_block(self, block_idx: int) -> Optional[nn.Module]:
+        """Find the MoE module within a transformer block."""
+        if block_idx in self._moe_modules_cache:
+            return self._moe_modules_cache[block_idx]
+
+        if not self.blocks or block_idx >= len(self.blocks):
+            return None
+
+        block = self.blocks[block_idx]
+        block_name = self.block_names[block_idx]
+            
+        # Search for MoE module by class name pattern from hook config
+        moe_class_name = self.hook_config.module_class_name_to_hook_regex
+
+        for name, module in block.named_modules():
+            if module.__class__.__name__ == moe_class_name:
+                self._moe_modules_cache[block_idx] = module
+                logger.debug(
+                    f"Found MoE module at {block_name}.{name}: {module.__class__.__name__}"
+                )
+                return module
+
+        logger.warning(
+            f"No MoE module found in block {block_idx} matching {moe_class_name}"
+        )
+        self._moe_modules_cache[block_idx] = None
+        return None
+
+    def _initialize_block_state(self, num_experts: int) -> Dict[str, Any]:
+        """Initialize state dictionary for a block."""
+        return initialize_pruning_state(num_experts)
+
+    def _block_at(self, block_idx: int):
+        """Return the block for a valid non-negative block index, else None."""
+        if not self.blocks or not (0 <= block_idx < len(self.blocks)):
+            return None
+        return self.blocks[block_idx]
+
+    def _move_block(self, block, block_idx: int, device: str) -> str:
+        """
+        Move a block to the requested device when possible.
+        Returns the block's final device.
+        """
+        try:
+            if has_meta_tensors(block):
+                logger.debug(
+                    "Block %s has meta tensors, skipping move to %s",
+                    block_idx,
+                    device,
+                )
+                return safe_get_device(block)
+
+            current_device = safe_get_device(block)
+            if current_device != device:
+                block.to(device)
+                logger.debug(
+                    "Moved block %s from %s to %s",
+                    block_idx,
+                    current_device,
+                    device,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Could not move block %s to %s: %s",
+                block_idx,
+                device,
+                exc,
+            )
+
+        return safe_get_device(block)
+
+    def _load_block_for_replay(self, block_idx: int) -> str:
+        """Load the requested transformer block and unload the previous one."""
+        block = self._block_at(block_idx)
+        if block is None:
+            raise IndexError("Invalid block index: %s", block_idx)
+
+        if self.currently_loaded_block_idx == block_idx:
+            return safe_get_device(block)
+
+        self._offload_current_block()
+
+        target_device = "cuda" if torch.cuda.is_available() else "cpu"
+        final_device = self._move_block(block, block_idx, target_device)
+
+        self.currently_loaded_block_idx = block_idx
+        logger.debug("Loaded block %s", block_idx)
+        return final_device
+
+    def _offload_current_block(self) -> None:
+        """Offload the current block to CPU and release memory."""
+        block_idx = self.currently_loaded_block_idx
+        if block_idx < 0:
+            return
+
+        block = self._block_at(block_idx)
+
+        try:
+            if block is not None:
+                self._move_block(block, block_idx, "cpu")
+        finally:
+            self.currently_loaded_block_idx = -1
+            cleanup_memory(synchronize=False)
+
+    def _capture_first_block_inputs(self, data_batches: List[torch.Tensor]):
+        """
+        Run calibration batches just far enough to cache the tensors entering
+        block 0.
+
+        Args:
+            data_batches: Calibration batches or token tensors
+        """
+        if not self.blocks:
+            raise ValueError("Layerwise replay requires at least one transformer block")
+
+        self.replay_cache.clear()
+
+        entry_block = self.blocks[0]
+        cpu_device = torch.device("cpu")
+        captured_batches: List[ReplayBatch] = []
+
+        def select_entrypoint_context() -> Tuple[torch.device, Optional[torch.dtype]]:
+            chosen_device: Optional[torch.device] = None
+            chosen_dtype: Optional[torch.dtype] = None
+
+            def scan_module(module: nn.Module) -> None:
+                nonlocal chosen_device, chosen_dtype
+
+                for parameter in module.parameters():
+                    if str(parameter.device) == "meta":
+                        continue
+                    if chosen_device is None:
+                        chosen_device = parameter.device
+                    if chosen_dtype is None:
+                        chosen_dtype = parameter.dtype
+                    if chosen_device is not None and chosen_dtype is not None:
+                        return
+
+                for buffer in module.buffers():
+                    if str(buffer.device) == "meta":
+                        continue
+                    if chosen_device is None:
+                        chosen_device = buffer.device
+                    if chosen_dtype is None and torch.is_floating_point(buffer):
+                        chosen_dtype = buffer.dtype
+                    if chosen_device is not None and chosen_dtype is not None:
+                        return
+
+            for module_name in self.non_backbone_modules:
+                module = get_module_by_name(self.model, module_name)
+                if module is None:
+                    continue
+                try:
+                    scan_module(module)
+                except Exception:
+                    continue
+                if chosen_device is not None and chosen_dtype is not None:
+                    break
+
+            try:
+                if chosen_dtype is None:
+                    for parameter in entry_block.parameters():
+                        if str(parameter.device) == "meta":
+                            continue
+                        if chosen_device is None:
+                            chosen_device = parameter.device
+                        chosen_dtype = parameter.dtype
+                        break
+
+                if chosen_device is None:
+                    for buffer in entry_block.buffers():
+                        if str(buffer.device) == "meta":
+                            continue
+                        chosen_device = buffer.device
+                        if chosen_dtype is None and torch.is_floating_point(buffer):
+                            chosen_dtype = buffer.dtype
+                        break
+            except Exception:
+                pass
+
+            if chosen_device is None:
+                chosen_device = torch.device(
+                    "cuda:0" if torch.cuda.is_available() else "cpu"
+                )
+
+            return chosen_device, chosen_dtype
+
+        seed_device, model_dtype = select_entrypoint_context()
+
+        def prepare_model_inputs(
+            batch: torch.Tensor | Dict[str, Any] | BatchEncoding,
+        ) -> Dict[str, Any]:
+            if isinstance(batch, torch.Tensor):
+                input_ids = batch.unsqueeze(0) if batch.dim() == 1 else batch
+                return {"input_ids": input_ids.to(seed_device)}
+
+            if isinstance(batch, (dict, BatchEncoding)):
+                prepared: Dict[str, Any] = {}
+                for key, value in batch.items():
+                    if not torch.is_tensor(value):
+                        prepared[key] = value
+                        continue
+
+                    tensor = value.unsqueeze(0) if value.dim() == 1 else value
+                    if tensor.is_floating_point() and model_dtype is not None:
+                        tensor = tensor.to(dtype=model_dtype)
+                    prepared[key] = tensor.to(seed_device)
+                return prepared
+
+            raise ValueError(f"Unsupported batch type: {type(batch)}")
+
+        def intercept_entry_inputs(_, args, kwargs):
+            replay_kwargs = {}
+            for key, value in kwargs.items():
+                if key in {"hidden_states", "attention_mask", "position_ids"}:
+                    continue
+                replay_kwargs[key] = move_to_device(value, cpu_device)
+
+            captured_batches.append(
+                ReplayBatch(
+                    inputs=[tensor.detach().cpu() for tensor in args],
+                    kwargs=LayerwiseMoEObserver._sanitize_cached_block_kwargs(
+                        replay_kwargs
+                    ),
+                    attention_mask=kwargs["attention_mask"].detach().cpu()
+                    if kwargs.get("attention_mask") is not None
+                    else None,
+                    position_ids=kwargs["position_ids"].detach().cpu()
+                    if kwargs.get("position_ids") is not None
+                    else None,
+                )
+            )
+
+            raise _FirstblockInputCaptured
+
+        logger.info("Seeding replay cache from the first decoder block")
+        hook_handle = entry_block.register_forward_pre_hook(
+            intercept_entry_inputs, with_kwargs=True
+        )
+
+        try:
+            for batch in tqdm(data_batches, desc="Seeding replay cache"):
+                try:
+                    self.model(**prepare_model_inputs(batch))
+                except _FirstblockInputCaptured:
+                    continue
+        finally:
+            hook_handle.remove()
+
+        for batch in captured_batches:
+            self.replay_cache.append(
+                inputs=batch.inputs,
+                kwargs=batch.kwargs,
+                attention_mask=batch.attention_mask,
+                position_ids=batch.position_ids,
+            )
+
+        logger.info("Prepared replay cache for %s batches", len(self.replay_cache))
+
+        if not self.replay_cache:
+            raise ValueError("Replay cache did not capture any first-block inputs")
+
+    @classmethod
+    def _sanitize_cached_block_kwargs(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Drop cache kwargs that cannot be replayed safely."""
+        sanitized = {}
+        for key, value in kwargs.items():
+            if key in cls._REPLAY_KWARG_DROP_KEYS:
+                continue
+            sanitized[key] = value
+        return sanitized
+
+    def _get_forward_signature_info(self, block_idx: int) -> Tuple[set[str], bool]:
+        """Return accepted forward kwargs and whether the block accepts **kwargs."""
+        cached = self._forward_signature_cache.get(block_idx)
+        if cached is not None:
+            return cached
+
+        signature = inspect.signature(self.blocks[block_idx].forward)
+        accepted_kwargs = set()
+        accepts_var_kwargs = False
+        for name, parameter in signature.parameters.items():
+            if name == "self":
+                continue
+            if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                accepts_var_kwargs = True
+            elif parameter.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ):
+                accepted_kwargs.add(name)
+
+        info = (accepted_kwargs, accepts_var_kwargs)
+        self._forward_signature_cache[block_idx] = info
+        return info
+
+    def _build_replay_kwargs(self, block_idx: int, block_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Build kwargs for replaying a decoder block without cache state."""
+        replay_kwargs = self._sanitize_cached_block_kwargs(block_kwargs)
+        accepted_kwargs, accepts_var_kwargs = self._get_forward_signature_info(block_idx)
+
+        for key, value in self._REPLAY_KWARG_FORCED_VALUES.items():
+            if accepts_var_kwargs or key in accepted_kwargs:
+                replay_kwargs[key] = value
+
+        if accepts_var_kwargs:
+            return replay_kwargs
+
+        return {key: value for key, value in replay_kwargs.items() if key in accepted_kwargs}    
+
+    @torch.inference_mode()
+    def _process_moe_activations(
+        self,
+        block_idx: int,
+        moe_module: nn.Module,
+        input_hidden_states: torch.Tensor,
+        device: torch.device,
+        attention_mask: torch.Tensor | None = None,
+    ):
+        """
+        Process MoE activations and compute pruning metrics.
+
+        This is the core function that computes REAP metrics for a single batch
+        through a single MoE block.
+
+        Args:
+            block_idx: Index of the transformer block
+            moe_module: The MoE module to process
+            input_hidden_states: Input tensor of shape [batch_size, seq_len, hidden_dim]
+            device: Target device for computation
+            attention_mask: Optional attention mask of shape [batch_size, seq_len] or
+                           [batch_size, 1, seq_len, seq_len]. If provided, padding tokens
+                           (where mask is 0) are excluded from metric computation.
+        """
+        from functools import reduce
+
+        # Get MoE configuration from hook config
+        num_experts = reduce(
+            getattr, self.hook_config.num_experts_attr_name.split("."), moe_module
+        )
+        top_k = reduce(getattr, self.hook_config.top_k_attr_name.split("."), moe_module)
+
+        if num_experts is None or top_k is None:
+            raise ValueError(
+                f"MoE module at block {block_idx} missing num_experts or top_k attributes"
+            )
+
+        batch_size, sequence_length, hidden_dim = input_hidden_states.shape
+        flat_input = input_hidden_states.view(-1, hidden_dim)
+
+        # Create valid token mask from attention mask
+        # This filters out padding tokens from metric computation
+        valid_token_mask = None
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(device)
+            # Handle different attention mask shapes
+            if attention_mask.dim() == 4:
+                # Shape: [batch_size, 1, seq_len, seq_len] - HuggingFace 4D causal mask
+                # Use the last row of each batch's mask to infer which token
+                # positions are valid for the full sequence. Some models pass
+                # a boolean mask (True = valid), others an additive mask
+                # (0 = valid, large negative = masked).
+                mask_row = attention_mask[:, 0, -1, :]
+                if mask_row.dtype == torch.bool:
+                    valid_token_mask = mask_row
+                else:
+                    valid_token_mask = mask_row == 0
+            elif attention_mask.dim() == 2:
+                # Shape: [batch_size, seq_len] - standard padding mask
+                # Convention: 1 = valid, 0 = padding.
+                valid_token_mask = attention_mask.bool()
+            else:
+                logger.warning(
+                    f"Unexpected attention_mask shape {attention_mask.shape}, ignoring"
+                )
+
+            if valid_token_mask is not None:
+                # Flatten to [batch_size * seq_len]
+                valid_token_mask = valid_token_mask.reshape(-1)
+
+        # Initialize state for this block if needed
+        if block_idx not in self.state:
+            self.state[block_idx] = self._initialize_block_state(num_experts)
+
+        # Compute activations for all experts
+        activations = torch.zeros((num_experts, *flat_input.shape), device=device)
+
+        def extract_router_logits(router_module, input):
+            result = router_module(input)
+            if isinstance(result, tuple):
+                *_, router_logits = result
+            else:
+                router_logits = result
+            return router_logits
+
+        if self.hook_config.fused_experts:
+            # Fused experts (e.g., Llama-4)
+            router_logits = extract_router_logits(moe_module.router, flat_input)
+            _, selected_experts = torch.topk(router_logits, top_k, dim=-1)
+            selected_experts = selected_experts.to(device)
+
+            router_indices = (
+                torch.arange(batch_size * sequence_length, device=device)
+                .view(1, -1)
+                .expand(num_experts, -1)
+            )
+            router_indices = router_indices.reshape(-1, 1).expand(-1, hidden_dim)
+            routed_in = torch.gather(
+                input=flat_input,
+                dim=0,
+                index=router_indices,
+            ).to(device)
+            routed_out = moe_module.experts(routed_in)
+            activations = routed_out.view(num_experts, *flat_input.shape)
+        else:
+            # Loop-based MoE execution
+            # First, we need to get router logits by doing a forward pass
+            # This is done via the router in the MoE module
+            if hasattr(moe_module, "gate"):
+                router_logits = extract_router_logits(moe_module.gate, flat_input)
+            elif hasattr(moe_module, "router"):
+                router_logits = extract_router_logits(moe_module.router, flat_input)
+            else:
+                raise ValueError(
+                    f"Cannot find router in MoE module at block {block_idx}"
+                )
+
+            _, selected_experts = torch.topk(router_logits, top_k, dim=-1)
+
+            # Compute activations for all experts
+            for idx, expert in enumerate(moe_module.experts):
+                activations[idx] = expert(flat_input).to(device)
+
+        update_pruning_state(
+            self.state[block_idx],
+            activations=activations,
+            selected_experts=selected_experts,
+            router_logits=router_logits,
+            num_experts=num_experts,
+            valid_token_mask=valid_token_mask,
+            renormalize_router_weights=self.hook_config.renormalize_router_weights,
+        )
+
+        # Clean up
+        del activations, selected_experts, router_logits
+        if valid_token_mask is not None:
+            del valid_token_mask
+        gc.collect()
+
+    @torch.inference_mode()
+    def _forward_block(
+        self,
+        block_idx: int,
+        before_forward: Optional[Callable[[], None]] = None,
+        after_forward: Optional[Callable[[torch.device, Optional[torch.Tensor]], None]] = None,
+    ) -> Dict[str, Any]:
+        """Forward cached hidden states through a single transformer block."""
+        block_name = (
+            self.block_names[block_idx]
+            if block_idx < len(self.block_names)
+            else f"block_{block_idx}"
+        )
+        logger.info(
+            f"Processing block {block_idx + 1}/{len(self.blocks)}: {block_name}"
+        )
+
+        self.model.eval()
+
+        if not self.blocks or block_idx >= len(self.blocks):
+            raise ValueError(f"Block {block_idx} not found")
+
+        device_str = self._load_block_for_replay(block_idx)
+        block = self.blocks[block_idx]
+
+        if device_str == "meta":
+            device_str = "cuda" if torch.cuda.is_available() else "cpu"
+        target_device = torch.device(device_str)
+
+        try:
+            if block_idx == 0 and not self.replay_cache:
+                raise ValueError(
+                    "First block inputs have not been captured; call "
+                    "_capture_first_block_inputs before forwarding block 0"
+                )
+            if not self.replay_cache:
+                raise ValueError("No cached block inputs available")
+
+            num_batches = len(self.replay_cache)
+            block_outputs = []
+
+            for batch_idx in tqdm(range(num_batches), desc=f"Processing {block_name}"):
+                
+                block_input, block_kwargs = self.replay_cache.materialize(
+                    batch_idx=batch_idx,
+                    target_device=target_device,
+                )
+                attention_mask = block_kwargs.get("attention_mask", None)
+
+                block_kwargs = self._build_replay_kwargs(block_idx, block_kwargs)
+                if before_forward is not None:
+                    before_forward()
+
+                with torch.amp.autocast(device_type="cuda", enabled=False):
+                    outputs = block(*block_input, **block_kwargs)
+
+                if isinstance(outputs, tuple):
+                    hidden_states = outputs[0]
+                else:
+                    hidden_states = outputs
+
+                if after_forward is not None:
+                    after_forward(target_device, attention_mask)
+
+                block_outputs.append([hidden_states.detach().cpu()])
+
+                del outputs, hidden_states, block_input, block_kwargs
+
+                if batch_idx % self._memory_cleanup_freq == 0:
+                    cleanup_memory(synchronize=False)
+
+            if block_idx < len(self.blocks) - 1:
+                self.replay_cache.replace_inputs(block_outputs)
+
+            logger.info(f"Completed block {block_idx}: processed {num_batches} batches")
+
+            return self.state.get(block_idx, {})
+
+        finally:
+            self._offload_current_block()
+
+    @torch.inference_mode()
+    def _record_activations_for_block(
+        self,
+        block_idx: int,
+        moe_module: Optional[nn.Module] = None,
+    ) -> Dict[str, Any]:
+        """
+        Record MoE activations and compute metrics for a single block.
+
+        Args:
+            block_idx: Index of the block to process
+            moe_module: Optional pre-resolved MoE module for this block
+
+        Returns:
+            Dictionary with computed metrics for this block
+        """
+        if moe_module is None:
+            moe_module = self._find_moe_module_in_block(block_idx)
+            if moe_module is None:
+                return self._forward_block(block_idx)
+
+        captured_moe_input: Dict[str, torch.Tensor] = {}
+        moe_hook_handle = None
+
+        def _capture_moe_input_hook(module, args, output):
+            captured_moe_input["input"] = args[0].detach()
+            return output
+
+        def _before_forward() -> None:
+            captured_moe_input.clear()
+
+        def _after_forward(
+            target_device: torch.device,
+            attention_mask: Optional[torch.Tensor],
+        ) -> None:
+            moe_input = captured_moe_input.get("input")
+            if moe_input is None:
+                raise RuntimeError(f"Failed to capture MoE input for block {block_idx}")
+
+            self._process_moe_activations(
+                block_idx,
+                moe_module,
+                moe_input,
+                target_device,
+                attention_mask=attention_mask,
+            )
+
+            del moe_input
+            captured_moe_input.clear()
+
+        moe_hook_handle = moe_module.register_forward_hook(_capture_moe_input_hook)
+
+        try:
+            return self._forward_block(
+                block_idx,
+                before_forward=_before_forward,
+                after_forward=_after_forward,
+            )
+
+        finally:
+            if moe_hook_handle is not None:
+                moe_hook_handle.remove()
+
+    @torch.inference_mode()
+    def _record_all_blocks_for_batch_group(
+        self,
+        data_batches: List[torch.Tensor],
+        save_path: Optional[pathlib.Path] = None,
+    ) -> Dict[int, Dict[str, Any]]:
+        """
+        Process all blocks for a single batch group.
+
+        Args:
+            data_batches: List of input batches to process for this group
+            save_path: Optional path to save intermediate results
+
+        Returns:
+            Dictionary mapping block numbers to their metrics
+        """
+        if not self.blocks:
+            raise ValueError("No transformer blocks found in model")
+
+        logger.info(
+            f"Processing {len(self.blocks)} blocks with {len(data_batches)} batches"
+        )
+
+        self._capture_first_block_inputs(data_batches)
+
+        for block_idx in range(len(self.blocks)):
+            moe_module = self._find_moe_module_in_block(block_idx)
+            if moe_module is None:
+                logger.warning(f"No MoE module in block {block_idx}, forwarding only")
+                self._forward_block(block_idx)
+            else:
+                self._record_activations_for_block(block_idx, moe_module=moe_module)
+
+            # Save intermediate results
+            if save_path:
+                intermediate_path = save_path / f"block_{block_idx:03d}_metrics.pt"
+                intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+                torch.save(self.state.get(block_idx, {}), intermediate_path)
+                logger.info(f"Saved intermediate results to {intermediate_path}")
+
+            cleanup_memory()
+
+            if torch.cuda.is_available():
+                allocated = torch.cuda.memory_allocated() / (1024**3)
+                reserved = torch.cuda.memory_reserved() / (1024**3)
+                logger.debug(
+                    f"GPU memory after block {block_idx}: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+                )
+
+        self.replay_cache.clear()
+        cleanup_memory(synchronize=False)
+
+        logger.info(f"Completed processing all {len(self.blocks)} blocks")
+        return self.report_state()
+
+    @torch.inference_mode()
+    def record_all_blocks(
+        self,
+        data_batches: List[torch.Tensor],
+        save_path: Optional[pathlib.Path] = None,
+        batch_group_size: Optional[int] = None,
+    ) -> Dict[int, Dict[str, Any]]:
+        """
+        Process all blocks sequentially, optionally in groups of batches.
+
+        Args:
+            data_batches: List of input batches to process
+            save_path: Optional path to save intermediate results
+            batch_group_size: Optional maximum number of batches to cache and process
+                per group. If None, all batches are processed in one pass.
+
+        Returns:
+            Dictionary mapping block numbers to their metrics
+        """
+        if batch_group_size is None or batch_group_size >= len(data_batches):
+            return self._record_all_blocks_for_batch_group(data_batches, save_path)
+
+        if batch_group_size < 1:
+            raise ValueError("batch_group_size must be at least 1 when provided")
+
+        total_groups = (len(data_batches) + batch_group_size - 1) // batch_group_size
+        logger.info(
+            "Processing %s blocks across %s batch groups of up to %s batches",
+            len(self.blocks),
+            total_groups,
+            batch_group_size,
+        )
+
+        for group_idx, start in enumerate(range(0, len(data_batches), batch_group_size)):
+            end = min(start + batch_group_size, len(data_batches))
+            batch_group = data_batches[start:end]
+            group_save_path = save_path
+            if group_save_path is not None:
+                group_save_path = group_save_path / f"group_{group_idx:03d}"
+
+            logger.info(
+                "Processing batch group %s/%s with %s batches",
+                group_idx + 1,
+                total_groups,
+                len(batch_group),
+            )
+            self._record_all_blocks_for_batch_group(
+                data_batches=batch_group,
+                save_path=group_save_path,
+            )
+            cleanup_memory()
+
+        return self.report_state()
+
+    def report_state(self) -> Dict[int, Dict[str, Any]]:
+        """
+        Report the current state with OnlineStatsTracker converted to means.
+
+        Returns:
+            State dictionary with metrics per block
+        """
+        return {
+            block_num: {
+                k: v.mean if isinstance(v, OnlineStatsTracker) else v
+                for k, v in block_state.items()
+            }
+            for block_num, block_state in self.state.items()
+        }
+
+    def save_state(self, file_path: pathlib.Path):
+        """Save the observer state to a file."""
+        if isinstance(file_path, str):
+            file_path = pathlib.Path(file_path)
+
+        if not file_path.parent.exists():
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        state_dict = self.report_state()
+
+        # Move all tensors to CPU
+        for block_num, block_state in state_dict.items():
+            for key, value in block_state.items():
+                if isinstance(value, torch.Tensor):
+                    state_dict[block_num][key] = value.cpu()
+
+        torch.save(state_dict, file_path)
+        logger.info(f"State saved to {file_path}")
+
+    def reset(self):
+        """Reset the observer state."""
+        del self.state
+        gc.collect()
+        self.state = {}
+        self._moe_modules_cache.clear()
+        self.replay_cache.clear()
+        cleanup_memory(synchronize=False)
+        logger.debug("Observer state reset")
+
+    def close_hooks(self):
+        """Clean up resources."""
+        self.reset()
+        for hook in self.hooks:
+            hook.remove()
+        self.hooks.clear()
+        logger.debug("Observer closed")

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -50,40 +50,11 @@ from reap.layerwise_observer import LayerwiseMoEObserver
 from reap.layerwise_model_utils import cleanup_memory
 from reap.eval import run_evaluate
 from reap.prune import prune as prune_model
+from reap.prune import get_pruned_model_dir
+from reap.main import dump_args_to_yaml, create_results_directory
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-
-def create_results_directory(model_name: str, dataset_name: str) -> pathlib.Path:
-    """Create a clean directory name from model and dataset names."""
-    import re
-
-    def str_to_directory_name(s: str) -> str:
-        return re.sub(r"[^\w\-_.]", "_", s)
-
-    model_clean = model_name.split("/")[-1]
-    model_clean = str_to_directory_name(model_clean)
-
-    if "," in dataset_name:
-        spec_hash = hashlib.md5(dataset_name.encode()).hexdigest()[:8]
-        dataset_clean = f"composite_{spec_hash}"
-        logger.info(
-            f"Composite dataset spec detected. Using directory name: {dataset_clean}"
-        )
-    else:
-        dataset_clean = dataset_name.split("/")[-1]
-        dataset_clean = str_to_directory_name(dataset_clean)
-
-    results_dir = pathlib.Path("./artifacts") / model_clean / dataset_clean
-
-    if results_dir.exists():
-        logger.warning(f"Directory '{results_dir}' already exists")
-    else:
-        results_dir.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Created artifacts directory: {results_dir}")
-
-    return results_dir
 
 
 def _get_observer_output_path(
@@ -241,62 +212,6 @@ def record_activations_layerwise(
     return observer_data
 
 
-def get_pruned_model_dir(
-    results_dir: pathlib.Path,
-    n_experts_to_prune: int,
-    total_experts: int,
-    prune_args: PruneArgs,
-    seed: int,
-    renorm: bool,
-) -> pathlib.Path:
-    """Generate output directory path for pruned model."""
-    compression_ratio_str = f"{(n_experts_to_prune / total_experts):.2f}"
-    pruned_model_name = f"layerwise_{prune_args.prune_method}"
-
-    if prune_args.perserve_super_experts:
-        pruned_model_name += "-perserve_super"
-    elif prune_args.perserve_outliers:
-        pruned_model_name += "-perserve_outlier"
-    if renorm:
-        pruned_model_name += f"-renorm_{str(renorm).lower()}"
-    pruned_model_name += f"-seed_{seed}"
-    pruned_model_name += f"-{compression_ratio_str}"
-
-    pruned_model_dir = results_dir / "pruned_models" / pruned_model_name
-    logger.info(f"Using seed {seed}, pruned model dir: {pruned_model_dir}")
-
-    return pruned_model_dir
-
-
-def dump_args_to_yaml(
-    pruned_model_dir: pathlib.Path,
-    **all_args,
-):
-    """Dump all arguments to a YAML file."""
-
-    def convert_paths_to_str(data):
-        if isinstance(data, dict):
-            return {k: convert_paths_to_str(v) for k, v in data.items()}
-        elif isinstance(data, list):
-            return [convert_paths_to_str(i) for i in data]
-        elif isinstance(data, pathlib.Path):
-            return str(data)
-        else:
-            return data
-
-    serializable_args = {}
-    for name, arg in all_args.items():
-        if dataclasses.is_dataclass(arg):
-            serializable_args[name] = convert_paths_to_str(dataclasses.asdict(arg))
-        else:
-            serializable_args[name] = convert_paths_to_str(arg)
-
-    output_path = pruned_model_dir / "reap_layerwise_args.yaml"
-    with open(output_path, "w") as f:
-        yaml.dump(serializable_args, f, default_flow_style=False)
-    logger.info(f"Arguments saved to {output_path}")
-
-
 def main():
     parser = HfArgumentParser(
         (
@@ -426,6 +341,7 @@ def main():
         prune_args,
         reap_args.seed,
         obs_args.renormalize_router_weights,
+        name_prefix="layerwise_",
     )
 
     # Check if already pruned
@@ -497,5 +413,6 @@ def main():
         )
 
 
+# TODO(ivanl): unify with prune.py entrypoint
 if __name__ == "__main__":
     main()

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -1,0 +1,501 @@
+"""
+Layerwise Expert Pruning for MoE Models.
+
+This module provides a memory-efficient entry point for expert pruning
+that processes the model one layer at a time, enabling calibration of
+large MoE models on a single GPU.
+
+Key differences from standard prune.py:
+1. Model is loaded on CPU with device_map="cpu"
+2. Only one transformer block is on GPU at a time
+3. Hidden states are cached between blocks
+4. Significantly reduced GPU memory requirements
+
+Usage:
+    python -m reap.layerwise_prune \
+        --model_name "Qwen/Qwen3-30B-A3B" \
+        --dataset_name "theblackcat102/evol-codealpaca-v1" \
+        --prune_method "reap" \
+        --compression_ratio 0.5 \
+        --batch_size 4
+"""
+
+from __future__ import annotations
+import logging
+import dataclasses
+import pathlib
+import hashlib
+from typing import Any, Dict, List
+import yaml
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, HfArgumentParser
+
+from accelerate.utils import set_seed
+
+from reap.args import (
+    ReapArgs,
+    ModelArgs,
+    EvalArgs,
+    PruneArgs,
+    ObserverArgs,
+    DatasetArgs,
+    ClusterArgs,
+    LayerwiseArgs,
+)
+from reap.data import load_category_batches, parse_composite_dataset_spec
+from reap.model_util import patched_model_map
+from reap.observer import OBSERVER_CONFIG_REGISTRY
+from reap.layerwise_observer import LayerwiseMoEObserver
+from reap.layerwise_model_utils import cleanup_memory
+from reap.eval import run_evaluate
+from reap.prune import prune as prune_model
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def create_results_directory(model_name: str, dataset_name: str) -> pathlib.Path:
+    """Create a clean directory name from model and dataset names."""
+    import re
+
+    def str_to_directory_name(s: str) -> str:
+        return re.sub(r"[^\w\-_.]", "_", s)
+
+    model_clean = model_name.split("/")[-1]
+    model_clean = str_to_directory_name(model_clean)
+
+    if "," in dataset_name:
+        spec_hash = hashlib.md5(dataset_name.encode()).hexdigest()[:8]
+        dataset_clean = f"composite_{spec_hash}"
+        logger.info(
+            f"Composite dataset spec detected. Using directory name: {dataset_clean}"
+        )
+    else:
+        dataset_clean = dataset_name.split("/")[-1]
+        dataset_clean = str_to_directory_name(dataset_clean)
+
+    results_dir = pathlib.Path("./artifacts") / model_clean / dataset_clean
+
+    if results_dir.exists():
+        logger.warning(f"Directory '{results_dir}' already exists")
+    else:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created artifacts directory: {results_dir}")
+
+    return results_dir
+
+
+def _get_observer_output_path(
+    results_dir: pathlib.Path,
+    dataset_name: str,
+    output_file_name: str,
+) -> pathlib.Path:
+    if (
+        dataset_name == "combined"
+        or parse_composite_dataset_spec(dataset_name) is not None
+    ):
+        return results_dir / "all" / output_file_name
+    return results_dir / "layerwise" / output_file_name
+
+
+def prepare_calibration_batches(
+    tokenizer,
+    ds_args: DatasetArgs,
+    obs_args: ObserverArgs,
+) -> List[torch.Tensor]:
+    """
+    Prepare calibration samples for layerwise processing.
+
+    Returns a list of tokenized input tensors.
+    """
+    logger.info(f"Loading dataset {ds_args.dataset_name}...")
+
+    composite_components = parse_composite_dataset_spec(
+        ds_args.dataset_name, default_split=ds_args.split
+    )
+
+    if composite_components is not None:
+        all_batches = []
+        total_samples = sum(component.num_batches for component in composite_components)
+        logger.info(
+            f"Composite dataset specified, overwriting given batches_per_category={obs_args.batches_per_category} "
+            f"with values in composite dataset spec."
+        )
+        logger.info(
+            f"Preparing composite calibration data with {len(composite_components)} "
+            f"components, {total_samples} total samples."
+        )
+
+        for component in composite_components:
+            comp_label = f"{component.name}[{component.split}]"
+            logger.info(
+                f"Loading composite component {comp_label} ({component.num_batches} batches)"
+            )
+            category_data_batches = load_category_batches(
+                dataset_name=component.name,
+                split=component.split,
+                subset=component.subset,
+                tokenizer=tokenizer,
+                model_max_length=obs_args.model_max_length,
+                split_by_category=False,
+                return_vllm_tokens_prompt=obs_args.return_vllm_tokens_prompt,
+                truncate=obs_args.truncate,
+                batches_per_category=component.num_batches,
+                batch_size=obs_args.batch_size,
+            )
+            for category, batches in category_data_batches.items():
+                all_batches.extend(batches)
+                logger.info(f"Added {len(batches)} batches from category: {category}")
+
+        logger.info(f"Total calibration batches: {len(all_batches)}")
+        return all_batches
+
+    category_data_batches = load_category_batches(
+        dataset_name=ds_args.dataset_name,
+        split=ds_args.split,
+        subset=ds_args.dataset_config_name,
+        tokenizer=tokenizer,
+        model_max_length=obs_args.model_max_length,
+        split_by_category=obs_args.split_by_category,
+        return_vllm_tokens_prompt=obs_args.return_vllm_tokens_prompt,
+        truncate=obs_args.truncate,
+        batches_per_category=obs_args.batches_per_category,
+        batch_size=obs_args.batch_size,
+    )
+
+    # Flatten all batches into a single list
+    all_batches = []
+    for category, samples in category_data_batches.items():
+        all_batches.extend(samples)
+        logger.info(f"Added {len(samples)} samples from category: {category}")
+
+    logger.info(f"Total calibration samples: {len(all_batches)}")
+    return all_batches
+
+
+def record_activations_layerwise(
+    model,
+    tokenizer,
+    data_batches: List[torch.Tensor],
+    ds_args: DatasetArgs,
+    obs_args: ObserverArgs,
+    layerwise_args: LayerwiseArgs,
+    results_dir: pathlib.Path,
+) -> Dict[int, Dict[str, Any]]:
+    """
+    Record MoE activations using layerwise processing.
+
+    This function processes the model one block at a time to minimize
+    GPU memory usage.
+    """
+    logger.info("Starting layerwise activation recording...")
+
+    # Create observer config from model-specific settings
+    model_class_name = model.__class__.__name__
+    if model_class_name not in OBSERVER_CONFIG_REGISTRY:
+        raise ValueError(
+            f"No observer configuration for model '{model_class_name}'. "
+            f"Supported: {list(OBSERVER_CONFIG_REGISTRY.keys())}"
+        )
+
+    hook_config = OBSERVER_CONFIG_REGISTRY[model_class_name](
+        renormalize_router_weights=obs_args.renormalize_router_weights,
+        record_pruning_metrics_only=obs_args.record_pruning_metrics_only,
+    )
+
+    # Create layerwise observer
+    observer = LayerwiseMoEObserver(
+        model=model,
+        hook_config=hook_config,
+    )
+
+    # Process all blocks
+    save_path = (
+        _get_observer_output_path(
+            results_dir,
+            ds_args.dataset_name,
+            obs_args.output_file_name,
+        ).parent
+        / "layerwise_intermediate"
+        if layerwise_args.save_intermediate
+        else None
+    )
+
+    observer_data = observer.record_all_blocks(
+        data_batches=data_batches,
+        save_path=save_path,
+        batch_group_size=layerwise_args.batch_group_size,
+    )
+
+    # Save complete state
+    output_file = _get_observer_output_path(
+        results_dir,
+        ds_args.dataset_name,
+        obs_args.output_file_name,
+    )
+    observer.save_state(output_file)
+
+    logger.info(f"Layerwise activation recording complete. Saved to {output_file}")
+
+    return observer_data
+
+
+def get_pruned_model_dir(
+    results_dir: pathlib.Path,
+    n_experts_to_prune: int,
+    total_experts: int,
+    prune_args: PruneArgs,
+    seed: int,
+    renorm: bool,
+) -> pathlib.Path:
+    """Generate output directory path for pruned model."""
+    compression_ratio_str = f"{(n_experts_to_prune / total_experts):.2f}"
+    pruned_model_name = f"layerwise_{prune_args.prune_method}"
+
+    if prune_args.perserve_super_experts:
+        pruned_model_name += "-perserve_super"
+    elif prune_args.perserve_outliers:
+        pruned_model_name += "-perserve_outlier"
+    if renorm:
+        pruned_model_name += f"-renorm_{str(renorm).lower()}"
+    pruned_model_name += f"-seed_{seed}"
+    pruned_model_name += f"-{compression_ratio_str}"
+
+    pruned_model_dir = results_dir / "pruned_models" / pruned_model_name
+    logger.info(f"Using seed {seed}, pruned model dir: {pruned_model_dir}")
+
+    return pruned_model_dir
+
+
+def dump_args_to_yaml(
+    pruned_model_dir: pathlib.Path,
+    **all_args,
+):
+    """Dump all arguments to a YAML file."""
+
+    def convert_paths_to_str(data):
+        if isinstance(data, dict):
+            return {k: convert_paths_to_str(v) for k, v in data.items()}
+        elif isinstance(data, list):
+            return [convert_paths_to_str(i) for i in data]
+        elif isinstance(data, pathlib.Path):
+            return str(data)
+        else:
+            return data
+
+    serializable_args = {}
+    for name, arg in all_args.items():
+        if dataclasses.is_dataclass(arg):
+            serializable_args[name] = convert_paths_to_str(dataclasses.asdict(arg))
+        else:
+            serializable_args[name] = convert_paths_to_str(arg)
+
+    output_path = pruned_model_dir / "reap_layerwise_args.yaml"
+    with open(output_path, "w") as f:
+        yaml.dump(serializable_args, f, default_flow_style=False)
+    logger.info(f"Arguments saved to {output_path}")
+
+
+def main():
+    parser = HfArgumentParser(
+        (
+            ReapArgs,
+            DatasetArgs,
+            ObserverArgs,
+            ModelArgs,
+            EvalArgs,
+            PruneArgs,
+            ClusterArgs,
+            LayerwiseArgs,
+        )
+    )
+    (
+        reap_args,
+        ds_args,
+        obs_args,
+        model_args,
+        eval_args,
+        prune_args,
+        cluster_args,
+        layerwise_args,
+    ) = parser.parse_args_into_dataclasses()
+
+    # Validation
+    if prune_args.perserve_super_experts and prune_args.perserve_outliers:
+        raise ValueError(
+            "Only one of perserve_super_experts or perserve_outliers can be True."
+        )
+    if (
+        layerwise_args.batch_group_size is not None
+        and layerwise_args.batch_group_size < 1
+    ):
+        raise ValueError("layerwise batch_group_size must be at least 1 when provided.")
+
+    set_seed(reap_args.seed)
+    results_dir = create_results_directory(model_args.model_name, ds_args.dataset_name)
+
+    # Get patched model name if needed
+    model_name = patched_model_map(model_args.model_name)
+
+    # Load tokenizer
+    logger.info(f"Loading tokenizer for {model_name}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = None
+
+    cached_data_path = _get_observer_output_path(
+        results_dir,
+        ds_args.dataset_name,
+        obs_args.output_file_name,
+    )
+
+    if ds_args.dataset_name == "combined":
+        if cached_data_path.exists():
+            logger.info(f"Loading cached observer data from {cached_data_path}")
+            observer_data = torch.load(cached_data_path, weights_only=False)
+        else:
+            raise RuntimeError(
+                f"Combined dataset requested but no pre-recorded data found at {cached_data_path}"
+            )
+    else:
+        # Prepare calibration samples
+        logger.info("Preparing calibration samples...")
+        data_batches = prepare_calibration_batches(tokenizer, ds_args, obs_args)
+
+        # Load model on CPU for layerwise processing
+        logger.info(f"Loading model {model_name} on CPU for layerwise processing...")
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            device_map="cpu",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            low_cpu_mem_usage=layerwise_args.low_cpu_mem_usage,
+        )
+        model.eval()
+
+        logger.info(f"Model loaded: {model.__class__.__name__}")
+        num_params = sum(p.numel() for p in model.parameters())
+        logger.info(f"Total parameters: {num_params / 1e9:.2f}B")
+
+        # Check for cached observer data
+        if cached_data_path.exists() and not obs_args.overwrite_observations:
+            logger.info(f"Loading cached observer data from {cached_data_path}")
+            observer_data = torch.load(cached_data_path, weights_only=False)
+        else:
+            # Record activations using layerwise processing
+            logger.info("Recording activations using layerwise processing...")
+            observer_data = record_activations_layerwise(
+                model,
+                tokenizer,
+                data_batches,
+                ds_args,
+                obs_args,
+                layerwise_args,
+                results_dir,
+            )
+
+    if reap_args.run_observer_only:
+        logger.info("Observer run completed. Exiting (run_observer_only=True)")
+        return
+
+    # Calculate number of experts to prune
+    n_experts_to_prune = prune_args.n_experts_to_prune
+    if n_experts_to_prune is None:
+        if cluster_args.compression_ratio is None:
+            raise ValueError(
+                "Either n_experts_to_prune or compression_ratio must be set."
+            )
+        total_experts = len(
+            observer_data[next(iter(observer_data))]["expert_frequency"]
+        )
+        n_experts_to_prune = int(total_experts * cluster_args.compression_ratio)
+        logger.info(
+            f"Calculated n_experts_to_prune: {n_experts_to_prune} "
+            f"(compression_ratio: {cluster_args.compression_ratio})"
+        )
+    else:
+        total_experts = len(
+            observer_data[next(iter(observer_data))]["expert_frequency"]
+        )
+
+    # Get output directory
+    pruned_model_dir = get_pruned_model_dir(
+        results_dir,
+        n_experts_to_prune,
+        total_experts,
+        prune_args,
+        reap_args.seed,
+        obs_args.renormalize_router_weights,
+    )
+
+    # Check if already pruned
+    if (
+        pruned_model_dir.exists()
+        and list(pruned_model_dir.glob("*.safetensors"))
+        and not prune_args.overwrite_pruned_model
+    ):
+        logger.info(
+            f"Pruned model already exists at {pruned_model_dir}. Skipping pruning."
+        )
+    else:
+        # Reload model on auto device for pruning
+        logger.info("Reloading model on GPU for pruning...")
+        if model is not None:
+            del model
+        cleanup_memory()
+
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            device_map="auto",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            local_files_only=True,
+        )
+
+        # Prune
+        logger.info(f"Pruning model to {total_experts - n_experts_to_prune} experts...")
+        prune_model(
+            observer_data,
+            model,
+            prune_args,
+            n_experts_to_prune,
+            pruned_model_dir,
+        )
+
+        # Save tokenizer
+        tokenizer.save_pretrained(pruned_model_dir)
+
+        # Save args
+        dump_args_to_yaml(
+            pruned_model_dir,
+            reap_args=reap_args,
+            ds_args=ds_args,
+            obs_args=obs_args,
+            model_args=model_args,
+            eval_args=eval_args,
+            prune_args=prune_args,
+            cluster_args=cluster_args,
+            layerwise_args=layerwise_args,
+        )
+
+        logger.info("Pruning completed successfully!")
+
+    # Evaluation
+    if reap_args.do_eval:
+        logger.info("Starting evaluation...")
+        if model is not None:
+            del model
+        del observer_data
+        cleanup_memory()
+
+        model_args.model_name = pruned_model_dir
+        run_evaluate(
+            model_args,
+            pruned_model_dir / "eval",
+            eval_args,
+            reap_args.seed,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reap/main.py
+++ b/src/reap/main.py
@@ -189,10 +189,14 @@ def record_activations(
     )
     if composite_components is not None:
         combined_batches = []
-        total_samples = sum(c.num_samples for c in composite_components)
+        total_batches = sum(c.num_batches for c in composite_components)
+        logger.info(
+            f"Composite dataset specified, overwriting given batches_per_category={obs_args.batches_per_category} "
+            f"with values in composite dataset spec."
+        )
         logger.info(
             f"Loading composite dataset with {len(composite_components)} "
-            f"components, {total_samples} total samples."
+            f"components, {total_batches} total data batches."
         )
 
         for comp_idx, component in enumerate(composite_components):
@@ -203,7 +207,7 @@ def record_activations(
             )
             logger.info(
                 f"[{comp_idx + 1}/{len(composite_components)}] Loading component: "
-                f"{comp_label} ({component.num_samples} samples)"
+                f"{comp_label} ({component.num_batches} batches)"
             )
             component_batches = load_category_batches(
                 dataset_name=component.name,
@@ -214,7 +218,7 @@ def record_activations(
                 split_by_category=False,
                 return_vllm_tokens_prompt=obs_args.return_vllm_tokens_prompt,
                 truncate=obs_args.truncate,
-                samples_per_category=component.num_samples,
+                batches_per_category=component.num_batches,
                 batch_size=obs_args.batch_size,
             )
             combined_batches.extend(component_batches["all"])
@@ -230,7 +234,7 @@ def record_activations(
             split_by_category=obs_args.split_by_category,
             return_vllm_tokens_prompt=obs_args.return_vllm_tokens_prompt,
             truncate=obs_args.truncate,
-            samples_per_category=obs_args.samples_per_category,
+            batches_per_category=obs_args.batches_per_category,
             batch_size=obs_args.batch_size,
         )
 

--- a/src/reap/main.py
+++ b/src/reap/main.py
@@ -610,27 +610,10 @@ def get_model_dir(
 
 
 def dump_args_to_yaml(
-    merged_model_dir: pathlib.Path,
-    reap_args: ReapArgs,
-    model_args: ModelArgs,
-    ds_args: DatasetArgs,
-    obs_args: ObserverArgs,
-    cluster_args: ClusterArgs,
-    kd_args: KdArgs,
-    eval_args: EvalArgs,
-    merge_args: MergeArgs,
+    pruned_model_dir: pathlib.Path,
+    **all_args,
 ):
     """Dump all arguments to a YAML file."""
-    all_args = {
-        "reap_args": dataclasses.asdict(reap_args),
-        "model_args": dataclasses.asdict(model_args),
-        "ds_args": dataclasses.asdict(ds_args),
-        "obs_args": dataclasses.asdict(obs_args),
-        "cluster_args": dataclasses.asdict(cluster_args),
-        "kd_args": dataclasses.asdict(kd_args),
-        "eval_args": dataclasses.asdict(eval_args),
-        "merge_args": dataclasses.asdict(merge_args),
-    }
 
     def convert_paths_to_str(data):
         if isinstance(data, dict):
@@ -642,12 +625,17 @@ def dump_args_to_yaml(
         else:
             return data
 
-    serializable_args = convert_paths_to_str(all_args)
+    serializable_args = {}
+    for name, arg in all_args.items():
+        if dataclasses.is_dataclass(arg):
+            serializable_args[name] = convert_paths_to_str(dataclasses.asdict(arg))
+        else:
+            serializable_args[name] = convert_paths_to_str(arg)
 
-    output_path = merged_model_dir / "reap_args.yaml"
+    output_path = pruned_model_dir / "reap_args.yaml"
     with open(output_path, "w") as f:
         yaml.dump(serializable_args, f, default_flow_style=False)
-    logger.info(f"All arguments saved to {output_path}")
+    logger.info(f"Arguments saved to {output_path}")
 
 
 def main():

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -7,7 +7,6 @@ from functools import reduce
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 import re
 from dataclasses import dataclass
 import logging
@@ -21,6 +20,7 @@ from reap.metrics import (
     OnlineStatsTracker,
     get_distance_fn,
 )
+from reap.pruning_metrics import initialize_pruning_state, update_pruning_state
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -273,16 +273,7 @@ class MoETransformerObserver(BaseTransformerObserver):
         output_hidden_states = output[0]
         device = "cpu"
         hidden_dim = output_hidden_states.shape[-1]
-        layer_state = {}
-
-        # unnormalized states (counts)
-        layer_state["total_tokens"] = torch.tensor(0, device=device, dtype=torch.long)
-        layer_state["expert_frequency"] = torch.zeros(
-            num_experts, device=device, dtype=torch.long
-        )
-        layer_state["pairwise_expert_frequency"] = torch.zeros(
-            num_experts, num_experts, dtype=torch.long, device=device
-        )
+        layer_state = initialize_pruning_state(num_experts, device=device)
 
         if not self.hook_config.record_pruning_metrics_only:
             # per routed token normalized states
@@ -319,36 +310,6 @@ class MoETransformerObserver(BaseTransformerObserver):
                 device=device,
                 dtype=torch.float32,
             )
-
-        # Expert Activation Norm
-        layer_state["ean_sum"] = torch.zeros(
-            (num_experts,), device=device, dtype=torch.float64, requires_grad=False
-        )
-        layer_state["weighted_ean_sum"] = torch.zeros(
-            (num_experts,), device=device, dtype=torch.float64, requires_grad=False
-        )
-        layer_state["ean_mean"] = OnlineStatsTracker(
-            shape=(num_experts,),
-            count_shape=(num_experts,),
-            device=device,
-            dtype=torch.float32,
-        )
-        layer_state["reap"] = OnlineStatsTracker(
-            shape=(num_experts,),
-            count_shape=(num_experts,),
-            device=device,
-            dtype=torch.float32,
-        )
-
-        # Weighted frequency
-        layer_state["weighted_expert_frequency_sum"] = torch.zeros(
-            (num_experts,), device=device, dtype=torch.float64, requires_grad=False
-        )
-
-        # super experts
-        layer_state["max_activations"] = torch.zeros(
-            (num_experts,), device=device, dtype=torch.float32, requires_grad=False
-        )
 
         return layer_state
 
@@ -422,65 +383,43 @@ class MoETransformerObserver(BaseTransformerObserver):
 
             del flat_input
             
-            # Filter out padding tokens if attention mask is provided
-            if flat_mask is not None:
-                num_tokens = flat_mask.sum().item()
-                # Filter selected_experts: (total_tokens, top_k) -> (num_valid_tokens, top_k)
-                selected_experts = selected_experts[flat_mask]
-                # Filter activations: (num_experts, total_tokens, hidden_dim) -> (num_experts, num_valid_tokens, hidden_dim)
-                activations = activations[:, flat_mask, :]
-                # Filter router_logits: (total_tokens, num_experts) -> (num_valid_tokens, num_experts)
-                router_logits = router_logits[flat_mask]
-            else:
-                num_tokens = batch_size * sequence_length
-
-            num_tokens = torch.tensor(num_tokens, device="cpu", dtype=torch.long)
-
-            # --- PRUNE/MERGE SALIENCY CRITERIA --------------------------------
-            # expert frequency
-            expert_frequency = torch.bincount(
-                selected_experts.view(-1), minlength=num_experts
-            ).to(device)
-            pairwise_expert_frequency = expert_frequency.unsqueeze(
-                0
-            ) + expert_frequency.unsqueeze(1)
-            pairwise_expert_frequency = pairwise_expert_frequency.to(device)
-
-            self.state[layer_number]["total_tokens"] += num_tokens
-            self.state[layer_number]["expert_frequency"] += expert_frequency.to(
-                "cpu", torch.long
-            )
-            self.state[layer_number]["pairwise_expert_frequency"] += (
-                pairwise_expert_frequency.to("cpu", torch.long)
+            pruning_batch = update_pruning_state(
+                self.state[layer_number],
+                activations=activations,
+                selected_experts=selected_experts,
+                router_logits=router_logits,
+                num_experts=num_experts,
+                valid_token_mask=flat_mask,
+                renormalize_router_weights=self.hook_config.renormalize_router_weights,
             )
 
             # Merging critera
             if not self.hook_config.record_pruning_metrics_only:
                 ttm_similarity_matrix = ttm_online(
-                    activations,
-                    selected_experts,
+                    pruning_batch.activations,
+                    pruning_batch.selected_experts,
                     distance_callable=distance_fn,
                     num_experts=num_experts,
-                    pairwise_expert_frequency=pairwise_expert_frequency,
+                    pairwise_expert_frequency=pruning_batch.pairwise_expert_frequency,
                 )
 
                 # ttm_similarity_matrix with pairwise frequency counts
                 self.state[layer_number]["ttm_similarity_matrix"].update(
-                    ttm_similarity_matrix, pairwise_expert_frequency
+                    ttm_similarity_matrix, pruning_batch.pairwise_expert_frequency
                 )
                 del ttm_similarity_matrix
 
                 routed_characteristic_activation = get_routed_characteristic_activation(
-                    activations,
-                    selected_experts,
-                    expert_frequency,
+                    pruning_batch.activations,
+                    pruning_batch.selected_experts,
+                    pruning_batch.expert_frequency,
                     device,
                     hidden_dim,
                     num_experts,
                 )
 
                 # routed_characteristic_activation with expert frequency counts
-                expert_freq_expanded = expert_frequency.unsqueeze(-1).expand(
+                expert_freq_expanded = pruning_batch.expert_frequency.unsqueeze(-1).expand(
                     (-1, hidden_dim)
                 )
                 self.state[layer_number]["routed_characteristic_activation"].update(
@@ -489,13 +428,13 @@ class MoETransformerObserver(BaseTransformerObserver):
                 del expert_freq_expanded, routed_characteristic_activation
 
                 online_characteristic_activation_dist = ca_dist_online(
-                    activations,
+                    pruning_batch.activations,
                     distance_callable=distance_fn,
                 ).to(device="cpu")
 
                 # online_characteristic_activation_dist with expert frequency counts
                 self.state[layer_number]["online_characteristic_activation_dist"].update(
-                    online_characteristic_activation_dist, num_tokens
+                    online_characteristic_activation_dist, pruning_batch.num_tokens
                 )
                 del online_characteristic_activation_dist
 
@@ -503,10 +442,10 @@ class MoETransformerObserver(BaseTransformerObserver):
                 # dim 0 "batch" dim, dims 1,2 expert pairwise, dim 3 token logits
                 router_logit_sim = (
                     distance_fn(
-                        router_logits.permute(1, 0).view(
+                        pruning_batch.router_logits.permute(1, 0).view(
                             1, num_experts, 1, -1
                         ),  # 1, num_experts, 1, logits
-                        router_logits.permute(1, 0).view(
+                        pruning_batch.router_logits.permute(1, 0).view(
                             1, 1, num_experts, -1
                         ),  # 1, 1, num_experts, logits
                     )
@@ -516,99 +455,21 @@ class MoETransformerObserver(BaseTransformerObserver):
 
                 # router_logit_similarity with total tokens count
                 self.state[layer_number]["router_logit_similiarity"].update(
-                    router_logit_sim, num_tokens
+                    router_logit_sim, pruning_batch.num_tokens
                 )
                 del router_logit_sim
 
                 # characteristic_activation with total tokens count
                 self.state[layer_number]["characteristic_activation"].update(
-                    activations.mean(dim=1), num_tokens
+                    pruning_batch.activations.mean(dim=1), pruning_batch.num_tokens
                 )
-
-            # Pruning criteria
-            ean_sum = torch.zeros(num_experts, device=device, dtype=torch.float64)
-            ean_mean = torch.zeros(num_experts, device=device, dtype=torch.float32)
-            weighted_ean_sum = torch.zeros(
-                num_experts, device=device, dtype=torch.float64
-            )
-            reap = torch.zeros(
-                num_experts, device=device, dtype=torch.float32
-            )
-            weighted_expert_frequency_sum = torch.zeros(
-                num_experts, device=device, dtype=torch.float64
-            )
-            routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float).to(
-                device
-            )  # tok, num_experts
-            prior_max_activations = self.state[layer_number]["max_activations"]
-            # renormalize
-            if self.hook_config.renormalize_router_weights:
-                topk_weights = torch.gather(
-                    routing_weights,
-                    1,
-                    selected_experts,
-                )  # (total_tokens, top_k)
-                routing_weights = routing_weights / topk_weights.sum(
-                    dim=-1, keepdim=True
-                )
-                routing_weights = torch.clamp(
-                    routing_weights, min=torch.finfo(routing_weights.dtype).eps
-                )
-                # routing_weights = routing_weights.to(device)
-
-            for i in range(num_experts):
-                active_mask = (selected_experts == i).any(dim=-1).to(device)
-                if not active_mask.any():
-                    continue
-                active_router_weights = routing_weights[active_mask, i]
-                ean_norm = torch.linalg.norm(activations[i, active_mask, :], dim=-1)
-                ean_sum[i] = ean_norm.sum().to(device)
-                ean_mean[i] = ean_norm.mean().to(device)
-                weighted_expert_frequency_sum[i] = active_router_weights.sum().to(
-                    device
-                )
-                weighted_ean_sum[i] = (
-                    (ean_norm * active_router_weights).sum().to(device)
-                )
-                reap[i] = (
-                    (ean_norm * active_router_weights).mean().to(device)
-                )
-
-                # super experts
-                selected_activations = activations[i, active_mask, :]
-                selected_activations_max = selected_activations.max().to(device="cpu")
-                if selected_activations_max > prior_max_activations[i]:
-                    self.state[layer_number]["max_activations"][i] = (
-                        selected_activations_max
-                    )
-                    prior_max_activations[i] = selected_activations_max
-
-            # ean
-            self.state[layer_number]["ean_sum"] += ean_sum.to(device="cpu")
-            self.state[layer_number]["ean_mean"].update(ean_mean, expert_frequency)
-            self.state[layer_number]["weighted_ean_sum"] += weighted_ean_sum.to(
-                device="cpu"
-            )
-            if reap.sum() == 0:
-                print("debug")
-            self.state[layer_number]["reap"].update(
-                reap, expert_frequency
-            )
-
-            # weighted_expert_frequency_sum
-            
-            self.state[layer_number]["weighted_expert_frequency_sum"] += (
-                weighted_expert_frequency_sum.to(device="cpu")
-            )
 
             # --- CLEAN UP -------------------------------------------------------------
             del (
                 activations,
                 selected_experts,
                 router_logits,
-                expert_frequency,
-                pairwise_expert_frequency,
-                prior_max_activations,
+                pruning_batch,
             )
             gc.collect()
 

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -82,8 +82,6 @@ def dump_args_to_yaml(
 def prune(
     observer_data,
     model,
-    tokenizer,
-    reap_args,
     prune_args,
     n_experts_to_prune,
     pruned_model_dir,
@@ -312,8 +310,6 @@ def main():
         prune(
             observer_data,
             model,
-            tokenizer,
-            reap_args,
             prune_args,
             n_experts_to_prune,
             pruned_model_dir,

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -16,7 +16,7 @@ from accelerate.utils import set_seed
 from accelerate.hooks import remove_hook_from_module
 
 
-from reap.main import record_activations, smoke_test, create_results_directory
+from reap.main import record_activations, smoke_test, create_results_directory, dump_args_to_yaml
 from reap.args import (
     ReapArgs,
     ModelArgs,
@@ -38,45 +38,6 @@ import shutil
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-
-def dump_args_to_yaml(
-    pruned_model_dir: pathlib.Path,
-    reap_args: ReapArgs,
-    ds_args: DatasetArgs,
-    obs_args: ObserverArgs,
-    model_args: ModelArgs,
-    eval_args: EvalArgs,
-    prune_args: PruneArgs,
-    cluster_args: ClusterArgs,
-):
-    """Dump all arguments to a YAML file."""
-    all_args = {
-        "reap_args": dataclasses.asdict(reap_args),
-        "ds_args": dataclasses.asdict(ds_args),
-        "obs_args": dataclasses.asdict(obs_args),
-        "model_args": dataclasses.asdict(model_args),
-        "eval_args": dataclasses.asdict(eval_args),
-        "prune_args": dataclasses.asdict(prune_args),
-        "cluster_args": dataclasses.asdict(cluster_args),
-    }
-
-    def convert_paths_to_str(data):
-        if isinstance(data, dict):
-            return {k: convert_paths_to_str(v) for k, v in data.items()}
-        elif isinstance(data, list):
-            return [convert_paths_to_str(i) for i in data]
-        elif isinstance(data, pathlib.Path):
-            return str(data)
-        else:
-            return data
-
-    serializable_args = convert_paths_to_str(all_args)
-
-    output_path = pruned_model_dir / "reap_args.yaml"
-    with open(output_path, "w") as f:
-        yaml.dump(serializable_args, f, default_flow_style=False)
-    logger.info(f"All arguments saved to {output_path}")
 
 
 def prune(
@@ -205,22 +166,31 @@ def prune(
 
 
 def get_pruned_model_dir(
-    results_dir,
-    n_experts_to_prune: str,
+    results_dir: pathlib.Path,
+    n_experts_to_prune: int,
     total_experts: int,
-    prune_args,
+    prune_args: PruneArgs,
     seed: int,
+    renorm: bool,
+    name_prefix: str = None,
 ) -> pathlib.Path:
+    """Generate output directory path for pruned model."""
     compression_ratio_str = f"{(n_experts_to_prune / total_experts):.2f}"
-    pruned_model_name = f"{prune_args.prune_method}"
+    name_prefix = "" if name_prefix is None else name_prefix
+    pruned_model_name = f"{name_prefix}{prune_args.prune_method}"
+
     if prune_args.perserve_super_experts:
         pruned_model_name += "-perserve_super"
     elif prune_args.perserve_outliers:
         pruned_model_name += "-perserve_outlier"
+    if renorm:
+        pruned_model_name += f"-renorm_{str(renorm).lower()}"
     pruned_model_name += f"-seed_{seed}"
     pruned_model_name += f"-{compression_ratio_str}"
+
     pruned_model_dir = results_dir / "pruned_models" / pruned_model_name
     logger.info(f"Using seed {seed}, pruned model dir: {pruned_model_dir}")
+
     return pruned_model_dir
 
 
@@ -294,7 +264,7 @@ def main():
             )
 
     pruned_model_dir = get_pruned_model_dir(
-        results_dir, n_experts_to_prune, total_experts, prune_args, reap_args.seed
+        results_dir, n_experts_to_prune, total_experts, prune_args, reap_args.seed, obs_args.renormalize_router_weights
     )
     if (
         pruned_model_dir.exists()

--- a/src/reap/pruning_metrics.py
+++ b/src/reap/pruning_metrics.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import torch
+import torch.nn.functional as F
+
+from reap.metrics import OnlineStatsTracker
+
+
+@dataclass
+class PreparedPruningBatch:
+    activations: torch.Tensor
+    selected_experts: torch.Tensor
+    router_logits: torch.Tensor
+    num_tokens: torch.Tensor
+    expert_frequency: torch.Tensor
+    pairwise_expert_frequency: torch.Tensor
+
+
+def initialize_pruning_state(
+    num_experts: int,
+    *,
+    device: str | torch.device = "cpu",
+) -> dict[str, Any]:
+    """Create the pruning-only per-layer state structure on the requested device.
+
+    The returned mapping matches the pruning-related subset of the observer state used
+    by both the standard and layerwise observers.
+    """
+    layer_state = {}
+    layer_state["total_tokens"] = torch.tensor(0, device=device, dtype=torch.long)
+    layer_state["expert_frequency"] = torch.zeros(
+        num_experts, device=device, dtype=torch.long
+    )
+    layer_state["pairwise_expert_frequency"] = torch.zeros(
+        num_experts, num_experts, dtype=torch.long, device=device
+    )
+    layer_state["ean_sum"] = torch.zeros(
+        (num_experts,), device=device, dtype=torch.float64, requires_grad=False
+    )
+    layer_state["weighted_ean_sum"] = torch.zeros(
+        (num_experts,), device=device, dtype=torch.float64, requires_grad=False
+    )
+    layer_state["ean_mean"] = OnlineStatsTracker(
+        shape=(num_experts,),
+        count_shape=(num_experts,),
+        device=device,
+        dtype=torch.float32,
+    )
+    layer_state["reap"] = OnlineStatsTracker(
+        shape=(num_experts,),
+        count_shape=(num_experts,),
+        device=device,
+        dtype=torch.float32,
+    )
+    layer_state["weighted_expert_frequency_sum"] = torch.zeros(
+        (num_experts,), device=device, dtype=torch.float64, requires_grad=False
+    )
+    layer_state["max_activations"] = torch.zeros(
+        (num_experts,), device=device, dtype=torch.float32, requires_grad=False
+    )
+    return layer_state
+
+
+def _prepare_pruning_batch(
+    *,
+    activations: torch.Tensor,
+    selected_experts: torch.Tensor,
+    router_logits: torch.Tensor,
+    num_experts: int,
+    valid_token_mask: Optional[torch.Tensor] = None,
+) -> PreparedPruningBatch:
+    """Normalize pruning inputs into a token-aligned batch representation.
+
+    This flattens `selected_experts`, optionally filters all tensors with a valid-token
+    mask, validates the resulting shapes, and precomputes token counts and routing
+    frequencies needed by downstream pruning updates.
+    """
+    device = activations.device
+    selected_experts = selected_experts.reshape(-1, selected_experts.shape[-1]).to(device)
+    router_logits = router_logits.to(device)
+
+    # Filter out padding tokens if attention mask is provided
+    if valid_token_mask is not None:
+        valid_token_mask = valid_token_mask.reshape(-1).bool().to(device)
+        # Filter activations: (num_experts, total_tokens, hidden_dim) -> (num_experts, num_valid_tokens, hidden_dim)
+        activations = activations[:, valid_token_mask, :]
+        # Filter selected_experts: (total_tokens, top_k) -> (num_valid_tokens, top_k)
+        selected_experts = selected_experts[valid_token_mask]
+        # Filter router_logits: (total_tokens, num_experts) -> (num_valid_tokens, num_experts)
+        router_logits = router_logits[valid_token_mask]
+
+    if activations.shape[0] != num_experts:
+        raise ValueError(
+            f"Expected activations for {num_experts} experts, got {activations.shape[0]}"
+        )
+    if router_logits.shape[1] != num_experts:
+        raise ValueError(
+            f"Expected router logits for {num_experts} experts, got {router_logits.shape[1]}"
+        )
+    if activations.shape[1] != selected_experts.shape[0]:
+        raise ValueError(
+            "Activations and selected expert token counts do not match: "
+            f"{activations.shape[1]} vs {selected_experts.shape[0]}"
+        )
+    if router_logits.shape[0] != selected_experts.shape[0]:
+        raise ValueError(
+            "Router logits and selected expert token counts do not match: "
+            f"{router_logits.shape[0]} vs {selected_experts.shape[0]}"
+        )
+
+    num_tokens = torch.tensor(selected_experts.shape[0], device="cpu", dtype=torch.long)
+    if selected_experts.numel() == 0:
+        expert_frequency = torch.zeros(num_experts, device=device, dtype=torch.long)
+    else:
+        expert_frequency = torch.bincount(
+            selected_experts.reshape(-1), minlength=num_experts
+        ).to(device)
+    pairwise_expert_frequency = expert_frequency.unsqueeze(0) + expert_frequency.unsqueeze(1)
+
+    return PreparedPruningBatch(
+        activations=activations,
+        selected_experts=selected_experts,
+        router_logits=router_logits,
+        num_tokens=num_tokens,
+        expert_frequency=expert_frequency,
+        pairwise_expert_frequency=pairwise_expert_frequency,
+    )
+
+
+def update_pruning_state(
+    layer_state: dict[str, Any],
+    *,
+    activations: torch.Tensor,
+    selected_experts: torch.Tensor,
+    router_logits: torch.Tensor,
+    num_experts: int,
+    valid_token_mask: Optional[torch.Tensor] = None,
+    renormalize_router_weights: bool = False,
+) -> PreparedPruningBatch:
+    """Accumulate pruning saliency metrics for one routed batch into `layer_state`.
+
+    The update computes expert/token counts, EAN aggregates, router-weighted variants,
+    REAP scores, and maximum activation magnitudes. It returns the prepared batch so
+    callers can reuse the filtered tensors and precomputed counts for additional metrics.
+    """
+    pruning_batch = _prepare_pruning_batch(
+        activations=activations,
+        selected_experts=selected_experts,
+        router_logits=router_logits,
+        num_experts=num_experts,
+        valid_token_mask=valid_token_mask,
+    )
+
+    device = pruning_batch.activations.device
+    layer_state["total_tokens"] += pruning_batch.num_tokens
+    layer_state["expert_frequency"] += pruning_batch.expert_frequency.to("cpu", torch.long)
+    layer_state["pairwise_expert_frequency"] += pruning_batch.pairwise_expert_frequency.to(
+        "cpu", torch.long
+    )
+
+    ean_sum = torch.zeros(num_experts, device=device, dtype=torch.float64)
+    ean_mean = torch.zeros(num_experts, device=device, dtype=torch.float32)
+    weighted_ean_sum = torch.zeros(num_experts, device=device, dtype=torch.float64)
+    reap = torch.zeros(num_experts, device=device, dtype=torch.float32)
+    weighted_expert_frequency_sum = torch.zeros(
+        num_experts, device=device, dtype=torch.float64
+    )
+
+    routing_weights = F.softmax(pruning_batch.router_logits, dim=1, dtype=torch.float).to(
+        device
+    )
+    if renormalize_router_weights and pruning_batch.selected_experts.numel() > 0:
+        topk_weights = torch.gather(
+            routing_weights,
+            1,
+            pruning_batch.selected_experts,
+        )
+        routing_weights = routing_weights / topk_weights.sum(dim=-1, keepdim=True)
+        routing_weights = torch.clamp(
+            routing_weights, min=torch.finfo(routing_weights.dtype).eps
+        )
+
+    for i in range(num_experts):
+        active_mask = (pruning_batch.selected_experts == i).any(dim=-1).to(device)
+        if not active_mask.any():
+            continue
+
+        selected_activations = pruning_batch.activations[i, active_mask, :]
+        active_router_weights = routing_weights[active_mask, i]
+        ean_norm = torch.linalg.norm(selected_activations, dim=-1)
+        ean_sum[i] = ean_norm.sum().to(device)
+        ean_mean[i] = ean_norm.mean().to(device)
+        weighted_expert_frequency_sum[i] = active_router_weights.sum().to(device)
+        weighted_ean_sum[i] = (ean_norm * active_router_weights).sum().to(device)
+        reap[i] = (ean_norm * active_router_weights).mean().to(device)
+
+        selected_activations_max = selected_activations.max().to(device="cpu")
+        if selected_activations_max > layer_state["max_activations"][i]:
+            layer_state["max_activations"][i] = selected_activations_max
+
+    layer_state["ean_sum"] += ean_sum.to(device="cpu")
+    layer_state["ean_mean"].update(
+        ean_mean.to("cpu"), pruning_batch.expert_frequency.to("cpu")
+    )
+    layer_state["weighted_ean_sum"] += weighted_ean_sum.to(device="cpu")
+    layer_state["reap"].update(
+        reap.to("cpu"), pruning_batch.expert_frequency.to("cpu")
+    )
+    layer_state["weighted_expert_frequency_sum"] += weighted_expert_frequency_sum.to(
+        device="cpu"
+    )
+
+    return pruning_batch

--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -1,0 +1,40 @@
+"""Smoke tests for CLI argument parsing (catches help-string formatting bugs)."""
+
+import sys
+import pytest
+from transformers import HfArgumentParser
+
+from reap.args import (
+    ReapArgs,
+    ModelArgs,
+    DatasetArgs,
+    ObserverArgs,
+    ClusterArgs,
+    EvalArgs,
+    PruneArgs,
+    MergeArgs,
+    LayerwiseArgs,
+)
+
+# The two parser configurations used by main.py and layerwise_prune.py
+MAIN_DATACLASSES = (
+    ReapArgs, ModelArgs, DatasetArgs, ObserverArgs,
+    ClusterArgs, EvalArgs, MergeArgs,
+)
+LAYERWISE_DATACLASSES = (
+    ReapArgs, DatasetArgs, ObserverArgs, ModelArgs,
+    EvalArgs, PruneArgs, ClusterArgs, LayerwiseArgs,
+)
+
+
+@pytest.mark.parametrize(
+    "dataclasses",
+    [MAIN_DATACLASSES, LAYERWISE_DATACLASSES],
+    ids=["main", "layerwise"],
+)
+def test_help_format_strings(dataclasses, monkeypatch):
+    """Ensure `--help` doesn't crash (e.g. unescaped %-codes in help text)."""
+    monkeypatch.setattr(sys, "argv", ["test"])
+    parser = HfArgumentParser(dataclasses)
+    # format_help() exercises the same %-expansion that triggers the bug
+    parser.format_help()

--- a/tests/test_composite_dataset_loading.py
+++ b/tests/test_composite_dataset_loading.py
@@ -15,11 +15,7 @@ REAL_COMPOSITE_SPEC = (
 
 def test_composite_dataset_loading_with_real_hf_datasets():
     from transformers import AutoTokenizer
-
-    try:
-        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-30B-A3B-Instruct-2507")
-    except Exception as exc:
-        pytest.skip(f"Required tokenizer could not be loaded: {exc}")
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-Coder-30B-A3B-Instruct")
 
     composite_components = parse_composite_dataset_spec(
         REAL_COMPOSITE_SPEC,
@@ -27,7 +23,7 @@ def test_composite_dataset_loading_with_real_hf_datasets():
     )
     assert composite_components is not None
     assert [
-        (component.name, component.subset, component.split, component.num_samples)
+        (component.name, component.subset, component.split, component.num_batches)
         for component in composite_components
     ] == [
         ("theblackcat102/evol-codealpaca-v1", None, "train", 8),
@@ -40,24 +36,18 @@ def test_composite_dataset_loading_with_real_hf_datasets():
 
     combined_batches = []
     for component in composite_components:
-        try:
-            component_batches = load_category_batches(
-                dataset_name=component.name,
-                split=component.split,
-                subset=component.subset,
-                tokenizer=tokenizer,
-                model_max_length=2048,
-                split_by_category=False,
-                return_vllm_tokens_prompt=False,
-                truncate=True,
-                samples_per_category=1,
-                batch_size=2,
-            )
-        except Exception as exc:
-            pytest.skip(
-                f"Real dataset component {component.name} could not be loaded with "
-                f"subset={component.subset} split={component.split}: {exc}"
-            )
+        component_batches = load_category_batches(
+            dataset_name=component.name,
+            split=component.split,
+            subset=component.subset,
+            tokenizer=tokenizer,
+            model_max_length=2048,
+            split_by_category=False,
+            return_vllm_tokens_prompt=False,
+            truncate=True,
+            batches_per_category=1,
+            batch_size=2,
+        )
 
         assert list(component_batches.keys()) == ["all"]
         assert len(component_batches["all"]) == 1

--- a/tests/test_layerwise_model_utils.py
+++ b/tests/test_layerwise_model_utils.py
@@ -1,0 +1,299 @@
+import pytest
+from transformers import (
+    DeepseekV2Config,
+    DeepseekV2ForCausalLM,
+    Ernie4_5_MoeConfig,
+    Ernie4_5_MoeForCausalLM,
+    Glm4MoeConfig,
+    Glm4MoeForCausalLM,
+    Llama4ForCausalLM,
+    Llama4TextConfig,
+    MixtralConfig,
+    MixtralForCausalLM,
+    Qwen3MoeConfig,
+    Qwen3MoeForCausalLM,
+)
+
+from reap.layerwise_observer import LayerwiseMoEObserver
+from reap.layerwise_model_utils import extract_model_components, is_decoder_block
+from reap.observer import (
+    DeepSeekMoEObserverHookConfig,
+    Ernie4_5MoEObserverHookConfig,
+    Glm44MoEObserverHookConfig,
+    Llama4MoEObserverHookConfig,
+    MixtralMoEObserverHookConfig,
+    Qwen3MoEObserverHookConfig,
+)
+
+
+EXPECTED_BLOCK_NAMES = ["model.layers.0", "model.layers.1", "model.layers.2"]
+EXPECTED_NON_BACKBONE_MODULES = ["model.embed_tokens", "model.norm", "lm_head"]
+
+
+def _make_qwen3_moe_model():
+    model = Qwen3MoeForCausalLM(
+        Qwen3MoeConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=8,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_experts=2,
+            num_experts_per_tok=1,
+            norm_topk_prob=False,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_llama4_model():
+    model = Llama4ForCausalLM(
+        Llama4TextConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            intermediate_size_mlp=32,
+            num_hidden_layers=3,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            num_local_experts=2,
+            num_experts_per_tok=1,
+            layer_types=["full_attention", "full_attention", "full_attention"],
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_mixtral_model():
+    model = MixtralForCausalLM(
+        MixtralConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=3,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_local_experts=2,
+            num_experts_per_tok=1,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_deepseek_v2_model():
+    model = DeepseekV2ForCausalLM(
+        DeepseekV2Config(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            n_shared_experts=None,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_ernie4_5_moe_model():
+    model = Ernie4_5_MoeForCausalLM(
+        Ernie4_5_MoeConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            moe_num_experts=2,
+            moe_k=1,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_glm4_moe_model():
+    model = Glm4MoeForCausalLM(
+        Glm4MoeConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+        )
+    )
+    model.eval()
+    return model
+
+
+MODEL_FACTORIES = [
+    pytest.param(_make_qwen3_moe_model, id="Qwen3MoeForCausalLM"),
+    pytest.param(_make_llama4_model, id="Llama4ForCausalLM"),
+    pytest.param(_make_mixtral_model, id="MixtralForCausalLM"),
+    pytest.param(_make_deepseek_v2_model, id="DeepseekV2ForCausalLM"),
+    pytest.param(_make_ernie4_5_moe_model, id="Ernie4_5_MoEForCausalLM"),
+    pytest.param(_make_glm4_moe_model, id="Glm4MoeForCausalLM"),
+]
+
+
+def _make_qwen3_hook_config():
+    return Qwen3MoEObserverHookConfig()
+
+
+def _make_llama4_hook_config():
+    return Llama4MoEObserverHookConfig()
+
+
+def _make_mixtral_hook_config():
+    return MixtralMoEObserverHookConfig()
+
+
+def _make_deepseek_hook_config():
+    return DeepSeekMoEObserverHookConfig()
+
+
+def _make_ernie4_5_hook_config():
+    return Ernie4_5MoEObserverHookConfig(
+        module_class_name_to_hook_regex="Ernie4_5_MoeSparseMoeBlock",
+        num_experts_attr_name="num_experts",
+        top_k_attr_name="top_k",
+    )
+
+
+def _make_glm4_hook_config():
+    return Glm44MoEObserverHookConfig()
+
+
+MOE_LOOKUP_CASES = [
+    pytest.param(
+        _make_qwen3_moe_model,
+        _make_qwen3_hook_config,
+        [0, 1, 2],
+        "mlp",
+        id="Qwen3MoeForCausalLM",
+    ),
+    pytest.param(
+        _make_llama4_model,
+        _make_llama4_hook_config,
+        [0, 1, 2],
+        "feed_forward",
+        id="Llama4ForCausalLM",
+    ),
+    pytest.param(
+        _make_mixtral_model,
+        _make_mixtral_hook_config,
+        [0, 1, 2],
+        "block_sparse_moe",
+        id="MixtralForCausalLM",
+    ),
+    pytest.param(
+        _make_deepseek_v2_model,
+        _make_deepseek_hook_config,
+        [0, 1, 2],
+        "mlp",
+        id="DeepseekV2ForCausalLM",
+    ),
+    pytest.param(
+        _make_ernie4_5_moe_model,
+        _make_ernie4_5_hook_config,
+        [1, 2],
+        "mlp",
+        id="Ernie4_5_MoEForCausalLM",
+    ),
+    pytest.param(
+        _make_glm4_moe_model,
+        _make_glm4_hook_config,
+        [1, 2],
+        "mlp",
+        id="Glm4MoeForCausalLM",
+    ),
+]
+
+
+def _detected_decoder_block_names(model):
+    return [
+        name
+        for name, module in model.named_modules()
+        if is_decoder_block(name, module)
+    ]
+
+
+def _model_layer_block_names(model):
+    return [f"model.layers.{index}" for index in range(len(model.model.layers))]
+
+
+def _relative_module_name(block, target_module):
+    for name, module in block.named_modules():
+        if module is target_module:
+            return name
+    return None
+
+
+@pytest.mark.parametrize("model_factory", MODEL_FACTORIES)
+def test_is_decoder_block_detects_only_transformer_layers(model_factory):
+    model = model_factory()
+
+    assert _model_layer_block_names(model) == EXPECTED_BLOCK_NAMES
+    assert _detected_decoder_block_names(model) == EXPECTED_BLOCK_NAMES
+
+
+@pytest.mark.parametrize("model_factory", MODEL_FACTORIES)
+def test_extract_model_components_returns_layers_container_and_nonbackbone_modules(
+    model_factory,
+):
+    model = model_factory()
+
+    block_names = _model_layer_block_names(model)
+    blocks, non_backbone_modules = extract_model_components(model, block_names)
+
+    assert blocks is model.model.layers
+    assert len(blocks) == len(EXPECTED_BLOCK_NAMES)
+    assert non_backbone_modules == EXPECTED_NON_BACKBONE_MODULES
+
+
+@pytest.mark.parametrize(
+    "model_factory,hook_config_factory,expected_moe_block_indices,expected_name",
+    MOE_LOOKUP_CASES,
+)
+def test_find_moe_module_in_block_matches_expected_modules_for_moe_layers(
+    model_factory,
+    hook_config_factory,
+    expected_moe_block_indices,
+    expected_name,
+):
+    model = model_factory()
+    observer = LayerwiseMoEObserver(
+        model,
+        hook_config=hook_config_factory(),
+        block_names=_model_layer_block_names(model),
+    )
+
+    try:
+        for block_idx in expected_moe_block_indices:
+            moe_module = observer._find_moe_module_in_block(block_idx)
+
+            assert moe_module is not None
+            assert (
+                moe_module.__class__.__name__
+                == observer.hook_config.module_class_name_to_hook_regex
+            )
+            assert (
+                _relative_module_name(observer.blocks[block_idx], moe_module)
+                == expected_name
+            )
+    finally:
+        observer.close_hooks()

--- a/tests/test_layerwise_observer.py
+++ b/tests/test_layerwise_observer.py
@@ -1,0 +1,224 @@
+import copy
+
+import torch
+from transformers import (
+    Ernie4_5_MoeConfig,
+    Ernie4_5_MoeForCausalLM,
+    Qwen3MoeConfig,
+    Qwen3MoeForCausalLM,
+)
+
+from reap.layerwise_observer import LayerwiseMoEObserver
+from reap.observer import (
+    Ernie4_5MoEObserverHookConfig,
+    MoETransformerObserver,
+    Qwen3MoEObserverHookConfig,
+)
+
+
+def _make_qwen3_moe_model(num_hidden_layers=1):
+    config = Qwen3MoeConfig(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=8,
+        moe_intermediate_size=8,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        num_experts=2,
+        num_experts_per_tok=1,
+        norm_topk_prob=False,
+    )
+    model = Qwen3MoeForCausalLM(config)
+    model.eval()
+    return model
+
+
+def _make_ernie4_5_partial_moe_model(num_hidden_layers=3):
+    config = Ernie4_5_MoeConfig(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=8,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        moe_num_experts=2,
+        moe_k=1,
+    )
+    model = Ernie4_5_MoeForCausalLM(config)
+    model.eval()
+    return model
+
+
+def _assert_layerwise_states_match(actual_state, expected_state):
+    assert actual_state.keys() == expected_state.keys()
+
+    metrics_to_compare = [
+        "total_tokens",
+        "expert_frequency",
+        "pairwise_expert_frequency",
+        "weighted_expert_frequency_sum",
+        "ean_sum",
+        "weighted_ean_sum",
+        "ean_mean",
+        "reap",
+    ]
+
+    for layer_idx in actual_state:
+        for metric in metrics_to_compare:
+            actual_value = actual_state[layer_idx][metric]
+            expected_value = expected_state[layer_idx][metric]
+
+            if actual_value.is_floating_point():
+                assert torch.allclose(
+                    actual_value, expected_value, rtol=1e-5, atol=1e-6
+                )
+            else:
+                assert torch.equal(actual_value, expected_value)
+
+
+def test_layerwise_observer_matches_standard_observer_for_batched_input():
+    torch.manual_seed(0)
+
+    model = _make_qwen3_moe_model()
+    layerwise_model = copy.deepcopy(model)
+
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]], dtype=torch.long),
+        "attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long),
+    }
+
+    hook_config = Qwen3MoEObserverHookConfig(record_pruning_metrics_only=True)
+
+    observer = MoETransformerObserver(
+        model,
+        hook_config=hook_config,
+    )
+    with observer.set_attention_mask(batch["attention_mask"]):
+        _ = model(**batch)
+    standard_state = observer.report_state()
+    observer.close_hooks()
+
+    layerwise_observer = LayerwiseMoEObserver(
+        layerwise_model,
+        hook_config=hook_config,
+    )
+    layerwise_state = layerwise_observer.record_all_blocks([batch])
+    layerwise_observer.close_hooks()
+
+    expected_tokens = batch["attention_mask"].sum()
+    assert layerwise_state[0]["total_tokens"] == expected_tokens
+    assert standard_state[0]["total_tokens"] == expected_tokens
+
+    assert torch.equal(
+        layerwise_state[0]["expert_frequency"], standard_state[0]["expert_frequency"]
+    )
+    assert torch.equal(
+        layerwise_state[0]["pairwise_expert_frequency"],
+        standard_state[0]["pairwise_expert_frequency"],
+    )
+    assert torch.allclose(
+        layerwise_state[0]["weighted_expert_frequency_sum"],
+        standard_state[0]["weighted_expert_frequency_sum"],
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        layerwise_state[0]["ean_sum"],
+        standard_state[0]["ean_sum"],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        layerwise_state[0]["weighted_ean_sum"],
+        standard_state[0]["weighted_ean_sum"],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        layerwise_state[0]["ean_mean"],
+        standard_state[0]["ean_mean"],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        layerwise_state[0]["reap"],
+        standard_state[0]["reap"],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+def test_layerwise_observer_grouped_batches_match_single_pass():
+    torch.manual_seed(0)
+
+    model = _make_qwen3_moe_model(num_hidden_layers=2)
+    grouped_model = copy.deepcopy(model)
+    hook_config = Qwen3MoEObserverHookConfig(record_pruning_metrics_only=True)
+
+    batches = [
+        {
+            "input_ids": torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]], dtype=torch.long),
+            "attention_mask": torch.tensor(
+                [[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long
+            ),
+        },
+        {
+            "input_ids": torch.tensor([[6, 7, 8, 9], [10, 11, 12, 0]], dtype=torch.long),
+            "attention_mask": torch.tensor(
+                [[1, 1, 1, 1], [1, 1, 1, 0]], dtype=torch.long
+            ),
+        },
+        {
+            "input_ids": torch.tensor([[13, 14, 0, 0], [15, 16, 17, 18]], dtype=torch.long),
+            "attention_mask": torch.tensor(
+                [[1, 1, 0, 0], [1, 1, 1, 1]], dtype=torch.long
+            ),
+        },
+    ]
+
+    single_pass_observer = LayerwiseMoEObserver(
+        model,
+        hook_config=hook_config,
+    )
+    single_pass_state = single_pass_observer.record_all_blocks(batches)
+    single_pass_observer.close_hooks()
+
+    grouped_observer = LayerwiseMoEObserver(
+        grouped_model,
+        hook_config=hook_config,
+    )
+    grouped_state = grouped_observer.record_all_blocks(batches, batch_group_size=1)
+    grouped_observer.close_hooks()
+
+    _assert_layerwise_states_match(grouped_state, single_pass_state)
+
+
+def test_layerwise_observer_forwards_dense_blocks_in_partial_moe_model():
+    torch.manual_seed(0)
+
+    model = _make_ernie4_5_partial_moe_model()
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]], dtype=torch.long),
+        "attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long),
+    }
+    hook_config = Ernie4_5MoEObserverHookConfig(
+        module_class_name_to_hook_regex="Ernie4_5_MoeSparseMoeBlock",
+        num_experts_attr_name="num_experts",
+        top_k_attr_name="top_k",
+        record_pruning_metrics_only=True,
+    )
+
+    layerwise_observer = LayerwiseMoEObserver(
+        model,
+        hook_config=hook_config,
+    )
+    try:
+        layerwise_state = layerwise_observer.record_all_blocks([batch])
+    finally:
+        layerwise_observer.close_hooks()
+
+    expected_tokens = batch["attention_mask"].sum().item()
+    assert set(layerwise_state) == {1, 2}
+    assert layerwise_state[1]["total_tokens"].item() == expected_tokens
+    assert layerwise_state[2]["total_tokens"].item() == expected_tokens

--- a/tests/test_pruning_e2e.py
+++ b/tests/test_pruning_e2e.py
@@ -1,0 +1,311 @@
+import copy
+import sys
+from dataclasses import replace
+
+import pytest
+import torch
+import transformers.utils as transformers_utils
+from transformers import (
+    DeepseekV2Config,
+    Ernie4_5_MoeConfig,
+    Glm4MoeConfig,
+    Qwen3MoeConfig,
+    Qwen3MoeForCausalLM,
+)
+from transformers.utils import TransformersKwargs
+
+from reap.args import DatasetArgs, LayerwiseArgs, ObserverArgs, PruneArgs
+from reap.layerwise_prune import record_activations_layerwise
+from reap.main import _setup_observer
+from reap.model_util import MODEL_ATTRS, get_moe
+from reap.prune import prune
+
+
+def _install_local_model_import_shims():
+    import transformers.models.deepseek_v2.configuration_deepseek_v2 as deepseek_config
+    import transformers.models.ernie4_5_moe.configuration_ernie4_5_moe as ernie_config
+
+    sys.modules.setdefault("reap.models.configuration_deepseek", deepseek_config)
+    sys.modules.setdefault("reap.models.configuration_ernie4_5_moe", ernie_config)
+    if not hasattr(transformers_utils, "LossKwargs"):
+        transformers_utils.LossKwargs = TransformersKwargs
+
+
+_install_local_model_import_shims()
+
+from reap.models.glm.modeling_glm4_moe import Glm4MoeForCausalLM
+from reap.models.modeling_deepseek import DeepseekV2ForCausalLM
+from reap.models.modeling_ernie4_5_moe import Ernie4_5_MoeForCausalLM
+
+
+def _make_mock_batches(*, include_use_cache: bool = False):
+    batches = [
+        {
+            "input_ids": torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]], dtype=torch.long),
+            "attention_mask": torch.tensor(
+                [[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long
+            ),
+        },
+        {
+            "input_ids": torch.tensor([[6, 7, 8, 9], [10, 11, 12, 0]], dtype=torch.long),
+            "attention_mask": torch.tensor(
+                [[1, 1, 1, 1], [1, 1, 1, 0]], dtype=torch.long
+            ),
+        },
+    ]
+    if include_use_cache:
+        for batch in batches:
+            batch["use_cache"] = False
+    return batches
+
+
+def _make_qwen3_model():
+    model = Qwen3MoeForCausalLM(
+        Qwen3MoeConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_experts=3,
+            num_experts_per_tok=1,
+            norm_topk_prob=False,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_glm_model():
+    model = Glm4MoeForCausalLM(
+        Glm4MoeConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_routed_experts=3,
+            num_experts_per_tok=1,
+            norm_topk_prob=False,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_deepseek_model():
+    model = DeepseekV2ForCausalLM(
+        DeepseekV2Config(
+            vocab_size=32,
+            pad_token_id=0,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_routed_experts=3,
+            num_experts_per_tok=1,
+            n_shared_experts=None,
+            first_k_dense_replace=0,
+            moe_layer_freq=1,
+            scoring_func="softmax",
+            q_lora_rank=8,
+            kv_lora_rank=4,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=8,
+            n_group=1,
+            topk_group=1,
+            use_cache=False,
+            norm_topk_prob=False,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _make_ernie_model():
+    model = Ernie4_5_MoeForCausalLM(
+        Ernie4_5_MoeConfig(
+            vocab_size=32,
+            pad_token_id=0,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            moe_num_experts=3,
+            moe_k=1,
+            use_moe=True,
+            sinkhorn_2gate=False,
+            sinkhorn_temp=1.0,
+            moe_gate_act="softmax",
+            moe_use_aux_free=True,
+            hidden_dropout_prob=0.0,
+            num_nextn_predict_layers=0,
+            weight_share_add_bias=False,
+            multi_token_pred_lambda=0.0,
+            moe_capacity=[3, 3, 3],
+            moe_layer_start_index=1,
+            moe_layer_end_index=2,
+            moe_layer_interval=1,
+            output_router_logits=False,
+        )
+    )
+    model.eval()
+    return model
+
+
+def _main_observer_data(model, batches, obs_args, results_dir):
+    observer = _setup_observer(model, obs_args)
+    try:
+        for batch in batches:
+            attention_mask = batch.get("attention_mask")
+            with observer.set_attention_mask(attention_mask):
+                model(**batch)
+        observer.save_state(results_dir / "main" / obs_args.output_file_name)
+        return observer.report_state()
+    finally:
+        observer.close_hooks()
+
+
+def _layerwise_observer_data(model, batches, obs_args, results_dir):
+    return record_activations_layerwise(
+        model=model,
+        tokenizer=None,
+        data_batches=batches,
+        ds_args=DatasetArgs(dataset_name="mock", split="train"),
+        obs_args=obs_args,
+        layerwise_args=LayerwiseArgs(batch_group_size=1, save_intermediate=False),
+        results_dir=results_dir,
+    )
+
+
+def _moe_layer_indices(observer_data):
+    return sorted(int(layer_idx) for layer_idx in observer_data)
+
+
+def _expert_count_for_layer(model, layer_idx):
+    moe = get_moe(model, layer_idx)
+    model_attrs = MODEL_ATTRS[model.__class__.__name__]
+    experts = getattr(moe, model_attrs["experts"])
+    if isinstance(experts, torch.nn.ModuleList):
+        return len(experts)
+    return moe.num_experts
+
+
+def _router_out_features_for_layer(model, layer_idx):
+    moe = get_moe(model, layer_idx)
+    model_attrs = MODEL_ATTRS[model.__class__.__name__]
+    router = getattr(moe, model_attrs["router"])
+    return router.out_features
+
+
+def _assert_prune_result(observer_data, pruned_model, n_experts_to_prune):
+    layer_indices = _moe_layer_indices(observer_data)
+    assert layer_indices, "Expected at least one MoE layer to be observed"
+
+    for layer_idx in layer_indices:
+        original_num_experts = observer_data[layer_idx]["expert_frequency"].shape[0]
+        expected_num_experts = original_num_experts - n_experts_to_prune
+        assert _expert_count_for_layer(pruned_model, layer_idx) == expected_num_experts
+        assert _router_out_features_for_layer(pruned_model, layer_idx) == expected_num_experts
+
+
+def _run_prune(observer_data, model, tmp_path, subdir_name):
+    pruned_model_dir = tmp_path / subdir_name
+    prune_args = PruneArgs(prune_method="frequency", n_experts_to_prune=1)
+    prune(
+        observer_data=observer_data,
+        model=model,
+        prune_args=prune_args,
+        n_experts_to_prune=prune_args.n_experts_to_prune,
+        pruned_model_dir=pruned_model_dir,
+    )
+    return pruned_model_dir, prune_args.n_experts_to_prune
+
+
+ARCHITECTURE_CASES = [
+    pytest.param(
+        _make_qwen3_model,
+        _make_mock_batches,
+        id="qwen3",
+    ),
+    pytest.param(
+        _make_glm_model,
+        _make_mock_batches,
+        id="glm-local",
+    ),
+    pytest.param(
+        _make_deepseek_model,
+        lambda: _make_mock_batches(include_use_cache=True),
+        id="deepseek-local",
+    ),
+    pytest.param(
+        _make_ernie_model,
+        _make_mock_batches,
+        id="ernie-local",
+    ),
+]
+
+
+@pytest.mark.parametrize("model_factory,batch_factory", ARCHITECTURE_CASES)
+def test_e2e_layerwise_pruning_functionality(model_factory, batch_factory, tmp_path):
+    torch.manual_seed(0)
+
+    base_model = model_factory()
+    main_model = copy.deepcopy(base_model)
+    layerwise_model = copy.deepcopy(base_model)
+    main_prune_model = copy.deepcopy(base_model)
+    layerwise_prune_model = copy.deepcopy(base_model)
+
+    batches = batch_factory()
+    obs_args = ObserverArgs(
+        output_file_name="mock_observations.pt",
+        record_pruning_metrics_only=True,
+        renormalize_router_weights=False,
+    )
+
+    main_results_dir = tmp_path / "main_results"
+    layerwise_results_dir = tmp_path / "layerwise_results"
+
+    main_observer_data = _main_observer_data(
+        model=main_model,
+        batches=batches,
+        obs_args=obs_args,
+        results_dir=main_results_dir,
+    )
+    layerwise_observer_data = _layerwise_observer_data(
+        model=layerwise_model,
+        batches=batches,
+        obs_args=replace(obs_args),
+        results_dir=layerwise_results_dir,
+    )
+
+    assert _moe_layer_indices(main_observer_data) == _moe_layer_indices(
+        layerwise_observer_data
+    )
+
+    _, n_experts_to_prune = _run_prune(
+        observer_data=main_observer_data,
+        model=main_prune_model,
+        tmp_path=tmp_path,
+        subdir_name="main_pruned",
+    )
+    _assert_prune_result(main_observer_data, main_prune_model, n_experts_to_prune)
+
+    _, n_experts_to_prune = _run_prune(
+        observer_data=layerwise_observer_data,
+        model=layerwise_prune_model,
+        tmp_path=tmp_path,
+        subdir_name="layerwise_pruned",
+    )
+    _assert_prune_result(
+        layerwise_observer_data, layerwise_prune_model, n_experts_to_prune
+    )

--- a/tests/test_pruning_metrics.py
+++ b/tests/test_pruning_metrics.py
@@ -1,0 +1,157 @@
+import torch
+
+from reap.pruning_metrics import initialize_pruning_state, update_pruning_state
+
+
+def test_update_pruning_state_filters_masked_tokens():
+    layer_state = initialize_pruning_state(2)
+
+    activations = torch.tensor(
+        [
+            [[3.0, 4.0], [1.0, 0.0], [5.0, 12.0]],
+            [[0.0, 2.0], [0.0, 4.0], [8.0, 15.0]],
+        ]
+    )
+    selected_experts = torch.tensor([[0], [1], [0]], dtype=torch.long)
+    router_logits = torch.tensor(
+        [[2.0, 1.0], [0.0, 3.0], [4.0, 0.0]], dtype=torch.float32
+    )
+    valid_token_mask = torch.tensor([True, False, True])
+
+    pruning_batch = update_pruning_state(
+        layer_state,
+        activations=activations,
+        selected_experts=selected_experts,
+        router_logits=router_logits,
+        num_experts=2,
+        valid_token_mask=valid_token_mask,
+    )
+
+    expected_router_logits = router_logits[valid_token_mask]
+    expected_routing_weights = torch.softmax(expected_router_logits, dim=1)
+    expected_weighted_freq = expected_routing_weights[:, 0].sum().to(torch.float64)
+    expected_weighted_ean_sum = (
+        torch.tensor([5.0, 13.0]) * expected_routing_weights[:, 0]
+    ).sum().to(torch.float64)
+    expected_reap = (
+        torch.tensor([5.0, 13.0]) * expected_routing_weights[:, 0]
+    ).mean()
+
+    assert pruning_batch.activations.shape == (2, 2, 2)
+    assert torch.equal(pruning_batch.selected_experts, torch.tensor([[0], [0]]))
+    assert torch.equal(pruning_batch.router_logits, expected_router_logits)
+    assert pruning_batch.num_tokens.item() == 2
+    assert torch.equal(pruning_batch.expert_frequency, torch.tensor([2, 0]))
+    assert torch.equal(
+        pruning_batch.pairwise_expert_frequency,
+        torch.tensor([[4, 2], [2, 0]]),
+    )
+
+    assert layer_state["total_tokens"].item() == 2
+    assert torch.equal(layer_state["expert_frequency"], torch.tensor([2, 0]))
+    assert torch.equal(
+        layer_state["pairwise_expert_frequency"],
+        torch.tensor([[4, 2], [2, 0]]),
+    )
+    assert torch.allclose(
+        layer_state["ean_sum"], torch.tensor([18.0, 0.0], dtype=torch.float64)
+    )
+    assert torch.allclose(
+        layer_state["weighted_ean_sum"],
+        torch.tensor([expected_weighted_ean_sum, 0.0], dtype=torch.float64),
+    )
+    assert torch.allclose(
+        layer_state["weighted_expert_frequency_sum"],
+        torch.tensor([expected_weighted_freq, 0.0], dtype=torch.float64),
+    )
+    assert torch.allclose(
+        layer_state["ean_mean"].mean,
+        torch.tensor([9.0, 0.0], dtype=torch.float32),
+    )
+    assert torch.allclose(
+        layer_state["reap"].mean,
+        torch.tensor([expected_reap, 0.0], dtype=torch.float32),
+    )
+    assert torch.equal(
+        layer_state["max_activations"],
+        torch.tensor([12.0, 0.0], dtype=torch.float32),
+    )
+
+
+def test_update_pruning_state_renormalizes_selected_router_weights():
+    layer_state = initialize_pruning_state(3)
+
+    activations = torch.tensor(
+        [
+            [[3.0, 4.0], [8.0, 15.0]],
+            [[0.0, 6.0], [0.0, 1.0]],
+            [[1.0, 0.0], [7.0, 24.0]],
+        ]
+    )
+    selected_experts = torch.tensor([[0, 1], [2, 0]], dtype=torch.long)
+    router_logits = torch.tensor(
+        [[2.0, 1.0, 0.0], [1.0, 0.0, 2.0]], dtype=torch.float32
+    )
+
+    pruning_batch = update_pruning_state(
+        layer_state,
+        activations=activations,
+        selected_experts=selected_experts,
+        router_logits=router_logits,
+        num_experts=3,
+        renormalize_router_weights=True,
+    )
+
+    routing_weights = torch.softmax(router_logits, dim=1)
+    topk_weights = torch.gather(routing_weights, 1, selected_experts)
+    renormalized_weights = routing_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    expert0_weighted_ean = 5.0 * renormalized_weights[0, 0] + 17.0 * renormalized_weights[1, 0]
+    expert1_weighted_ean = 6.0 * renormalized_weights[0, 1]
+    expert2_weighted_ean = 25.0 * renormalized_weights[1, 2]
+
+    assert torch.equal(pruning_batch.expert_frequency, torch.tensor([2, 1, 1]))
+    assert torch.equal(
+        layer_state["pairwise_expert_frequency"],
+        torch.tensor([[4, 3, 3], [3, 2, 2], [3, 2, 2]]),
+    )
+    assert torch.allclose(
+        layer_state["ean_sum"],
+        torch.tensor([22.0, 6.0, 25.0], dtype=torch.float64),
+    )
+    assert torch.allclose(
+        layer_state["ean_mean"].mean,
+        torch.tensor([11.0, 6.0, 25.0], dtype=torch.float32),
+    )
+    assert torch.allclose(
+        layer_state["weighted_expert_frequency_sum"],
+        torch.tensor(
+            [
+                renormalized_weights[0, 0] + renormalized_weights[1, 0],
+                renormalized_weights[0, 1],
+                renormalized_weights[1, 2],
+            ],
+            dtype=torch.float64,
+        ),
+    )
+    assert torch.allclose(
+        layer_state["weighted_ean_sum"],
+        torch.tensor(
+            [expert0_weighted_ean, expert1_weighted_ean, expert2_weighted_ean],
+            dtype=torch.float64,
+        ),
+    )
+    assert torch.allclose(
+        layer_state["reap"].mean,
+        torch.tensor(
+            [
+                expert0_weighted_ean / 2.0,
+                expert1_weighted_ean,
+                expert2_weighted_ean,
+            ],
+        ),
+    )
+    assert torch.equal(
+        layer_state["max_activations"],
+        torch.tensor([15.0, 6.0, 24.0], dtype=torch.float32),
+    )


### PR DESCRIPTION
## Summary

This PR adds a `LayerwiseMoEObserver` that executes model forward block by block with selective loading/offloading to cap peak GPU memory. It also refactors pruning metric accumulation into a shared module, aligns calibration semantics around `batches` (replacing `samples`) and adds test coverage for the new layerwise (blockwise) flow.

## What changed

### 1. Added layer-wise calibration + pruning entrypoint
- Introduced `src/reap/layerwise_prune.py` as a new pruning entrypoint that:
  - loads the model on CPU,
  - calibrates one transformer block at a time,
  - caches hidden states between blocks,
  - then reloads the model for pruning/eval,
  - pruning goes through the same codepath as before.

- Added `src/reap/layerwise_observer.py` implementing a block-wise MoE observer that:
  - captures first-block inputs,
  - replays cached activations block by block,
  - computes the same pruning metrics as the standard observer (via shared methods),
  - optionally processes calibration data in batch groups to reduce CPU RAM (for large datasets 10k+ samples).
- Added `src/reap/layerwise_model_utils.py` with block detection, model component extraction, device movement, and memory cleanup utilities.
- Added `experiments/pruning-layerwise-cli.sh` for running the new workflow.

### 2. Refactored pruning metric computation into shared logic
- Added `src/reap/pruning_metrics.py` to centralize pruning-state initialization and metric updates.
- Updated the standard observer in `src/reap/observer.py` to use this shared implementation.

## Testing

Added/updated tests covering:
- CLI help formatting smoke tests
- composite dataset parsing/loading with `num_batches`
- decoder block detection and model component extraction
- MoE module lookup across supported architectures
- parity between standard observer and layer-wise observer

## ML testing

Parity of layer-wise and main pruning codepath:

### Qwen/Qwen3-30B-A3B @ 50% pruning

Setup: 1024 samples of `theblackcat102/evol-codealpaca-v1`, MSL=2048, pruning method REAP, renorm=True

#### Layerwise pruning evals (3 runs for each):

- HumanEval base: 92.07% ± 0.50%
- HumanEval plus: 85.37% ± 0.50%
- MBPP base: 81.48% ± 0.00%
- MBPP plus: 70.11% ± 0.00%
- LCB: 30.22% ± 1.19%

#### Main pruning codepath evals (3 runs for each):

- HumanEval base: 91.67% ± 0.70%
- HumanEval plus: 85.57% ± 0.70%
- MBPP base: 81.83% ± 0.15%
- MBPP plus: 70.46% ± 0.15%
- LCB: 28.02% ± 1.45%


### Qwen/Qwen3-Coder-30B-A3B-Instruct @ 50% pruning

Setup: 1024 samples of `theblackcat102/evol-codealpaca-v1`, MSL=2048, pruning method REAP, renorm=True

#### Layerwise pruning evals (3 runs for each):

- HumanEval base: 91.26% ± 0.29%
- HumanEval plus: 88.61% ± 0.29%
- MBPP base: 83.69% ± 0.12%
- MBPP plus: 69.58% ± 0.21%
- LCB: 33.33% ± 1.13%

#### Main pruning codepath evals (3 runs for each):

- HumanEval base: 91.16% ± 0.30%
- HumanEval plus: 88.41% ± 0.00%
- MBPP base: 83.86% ± 0.00%
- MBPP plus: 69.84% ± 0.00%
- LCB: 32.60% ± 0.52%

### zai-org/GLM-4.5-Air @ 50% pruning

Setup: 1024 samples of `theblackcat102/evol-codealpaca-v1`, MSL=2048, pruning method REAP, renorm=True

#### Layerwise pruning evals (1 run):

- HumanEval base: 76.83%
- HumanEval plus: 75.00%
- MBPP base: 70.11%
- MBPP plus: 60.32%

#### Main pruning codepath evals (1 run):

- HumanEval base: 73.78%
- HumanEval plus: 70.73%
- MBPP base: 70.11%
- MBPP plus: 59.52%