### PR TITLE
feat: add MiniMax M2 (MiniMaxM2ForCausalLM) support

### DIFF
--- a/src/reap/model_util.py
+++ b/src/reap/model_util.py
@@ -115,6 +115,21 @@ MODEL_ATTRS = {
         "num_experts": "n_routed_experts",
         "num_experts_per_tok": "num_experts_per_tok",
     },
+    "MiniMaxM2ForCausalLM": {
+        # MiniMaxM2MLP uses w1/w2/w3 instead of gate_proj/up_proj/down_proj.
+        # Confirmed against HF modeling_minimax_m2.py and SGLang minimax_m2.py
+        # (ckpt_gate_proj_name="w1", ckpt_down_proj_name="w2", ckpt_up_proj_name="w3").
+        # block_sparse_moe is the MoE attribute on MiniMaxM2DecoderLayer.
+        "moe_block": "block_sparse_moe",
+        "gate_proj": "w1",
+        "up_proj": "w3",
+        "down_proj": "w2",
+        "experts": "experts",
+        "fused": False,
+        "router": "gate",
+        "num_experts": "num_local_experts",
+        "num_experts_per_tok": "num_experts_per_tok",
+    },
 }
 
 

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -663,6 +663,13 @@ class Glm44MoEObserverHookConfig(MoETransformerObserverConfig):
     fused_experts: bool = False
 
 
+@dataclass
+class MiniMaxM2MoEObserverHookConfig(MoETransformerObserverConfig):
+    # Hooks onto MiniMaxM2SparseMoeBlock.
+    # MiniMaxM2Experts exposes .num_experts and .top_k, matching base class defaults.
+    module_class_name_to_hook_regex: Optional[str] = "MiniMaxM2SparseMoeBlock"
+
+
 OBSERVER_CONFIG_REGISTRY = {
     "Qwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
     "NonUniformQwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
@@ -672,4 +679,5 @@ OBSERVER_CONFIG_REGISTRY = {
     "Ernie4_5_MoEForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Ernie4_5_MoeForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Glm4MoeForCausalLM": Glm44MoEObserverHookConfig,
+    "MiniMaxM2ForCausalLM": MiniMaxM2MoEObserverHookConfig,
 }


### PR DESCRIPTION
## Summary

Adds `MODEL_ATTRS` entry and observer config for `MiniMaxM2ForCausalLM`, enabling REAP expert pruning on MiniMax M2.x models (M2, M2.1, M2.5, M2.7).

Cerebras has already published REAP-pruned MiniMax M2 and M2.5 checkpoints on HuggingFace ([MiniMax-M2.5-REAP-139B-A10B](https://huggingface.co/cerebras/MiniMax-M2.5-REAP-139B-A10B), [MiniMax-M2.5-REAP-172B-A10B](https://huggingface.co/cerebras/MiniMax-M2.5-REAP-172B-A10B)), but the corresponding model support was not upstreamed. This patch enables the community to reproduce those results and apply REAP to MiniMax M2.7.

## Changes

### `src/reap/model_util.py`
Adds `MiniMaxM2ForCausalLM` to `MODEL_ATTRS`:
- `moe_block: "block_sparse_moe"` — the MoE attribute on `MiniMaxM2DecoderLayer`
- `gate_proj: "w1"`, `up_proj: "w3"`, `down_proj: "w2"` — `MiniMaxM2MLP` uses non-standard weight names
- `router: "gate"`, `num_experts: "num_local_experts"`

### `src/reap/observer.py`
Adds `MiniMaxM2MoEObserverHookConfig` hooking onto `MiniMaxM2SparseMoeBlock`. `MiniMaxM2Experts` exposes `.num_experts` and `.top_k` directly, matching the base class defaults — no attribute overrides needed.

## Verification

Weight name mapping confirmed against:
- HF [`modeling_minimax_m2.py`](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/modeling_minimax_m2.py) (`MiniMaxM2MLP` class uses `w1`/`w2`/`w3`)
- SGLang [`minimax_m2.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/minimax_m2.py) (`ckpt_gate_proj_name="w1"`, `ckpt_down_proj_name="w2"`, `ckpt_up_proj_name="w3"`)
- [`yujiepan/minimax-m2.5-tiny-random`](https://huggingface.co/yujiepan/minimax-m2.5-tiny-random) model structure printout confirming `block_sparse_moe` attribute name

Applies to all MiniMax M2 variants sharing the `MiniMaxM2ForCausalLM` architecture: M2, M2.1, M2.5, M2.7.