### PR TITLE
Add generic local-dataset fallback for calibration corpora

### DIFF
--- a/src/reap/data.py
+++ b/src/reap/data.py
@@ -242,10 +242,18 @@ def load_category_batches(
     # load dataset processor
     proc_cls = DATASET_REGISTRY.get(dataset_name)
     if proc_cls is None:
-        raise ValueError(
-            f"No DatasetProcessor registered for '{dataset_name}'. "
-            f"Supported: {list(DATASET_REGISTRY.keys())}"
-        )
+        # Local addition: local plain-text datasets (a directory with a "text"
+        # column, e.g. one produced by el_export_calibration_corpus.py) don't need a
+        # bespoke DatasetProcessor registered ahead of time -- fall back to a
+        # generic LM-style one instead of raising.
+        if "text" in getattr(raw_ds, "column_names", []):
+            proc_cls = GenericLMDataset
+        else:
+            raise ValueError(
+                f"No DatasetProcessor registered for '{dataset_name}' and it has no "
+                f"'text' column to fall back to a generic LM dataset. "
+                f"Supported named datasets: {list(DATASET_REGISTRY.keys())}"
+            )
 
     # init processor & process dataset
     processor = proc_cls(
@@ -723,6 +731,20 @@ class MagicoderEvolInstructChatDataset(ChatDatasetProcessor):
 
 
 class C4LMDataset(LMDatasetProcessor):
+    category_field: str = None
+
+    @staticmethod
+    def _map_fn(sample: dict[str, any]) -> dict[str, any]:
+        return sample
+
+
+class GenericLMDataset(LMDatasetProcessor):
+    """Local addition: fallback for any plain-text local dataset (a directory
+    containing a .jsonl/.json file with a "text" field per row, e.g. one produced by
+    el_export_calibration_corpus.py) that isn't in DATASET_REGISTRY. Identical to
+    C4LMDataset -- kept as a separate class so registry lookups stay explicit about
+    which datasets are known-good vs. this generic catch-all."""
+
     category_field: str = None
 
     @staticmethod

--- a/src/reap/model_util.py
+++ b/src/reap/model_util.py
@@ -115,12 +115,33 @@ MODEL_ATTRS = {
         "num_experts": "n_routed_experts",
         "num_experts_per_tok": "num_experts_per_tok",
     },
+    # Local addition: not yet in upstream REAP. Qwen3_5MoeExperts stores experts as
+    # fused 3D parameter tensors (gate_up_proj, down_proj), same shape as Llama4's
+    # fused MoE layer above -- reuses that code path via fused=True. shared_expert is
+    # a separate always-on MLP outside this registry and is untouched by pruning.
+    "Qwen3_5MoeForConditionalGeneration": {
+        "moe_block": "mlp",
+        "gate_proj": "gate_up_proj",
+        "up_proj": "gate_up_proj",
+        "down_proj": "down_proj",
+        "experts": "experts",
+        "fused": True,
+        "router": "gate",
+        "num_experts": "num_experts",
+        "num_experts_per_tok": "num_experts_per_tok",
+    },
 }
 
 
 def get_moe(model, layer):
     moe_attr_name = MODEL_ATTRS.get(model.__class__.__name__)["moe_block"]
-    return getattr(model.model.layers[layer], moe_attr_name)
+    # Local addition: Qwen3_5MoeForConditionalGeneration nests decoder layers one
+    # level deeper (model.model.language_model.layers) than the causal-LM-only
+    # classes this originally targeted (model.model.layers).
+    decoder = model.model
+    if hasattr(decoder, "language_model"):
+        decoder = decoder.language_model
+    return getattr(decoder.layers[layer], moe_attr_name)
 
 
 def assert_merge(model, merged_moe, cluster_label):

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -524,6 +524,18 @@ class Glm44MoEObserverHookConfig(MoETransformerObserverConfig):
     fused_experts: bool = False
 
 
+# Local addition: not yet in upstream REAP, mirrors Llama4MoEObserverHookConfig
+# since Qwen3_5MoeExperts is likewise fused (see model_util.py's MODEL_ATTRS patch).
+# Qwen3_5MoeSparseMoeBlock itself has no num_experts/top_k attrs -- they live on its
+# .experts and .gate submodules respectively.
+@dataclass
+class Qwen3_5MoEObserverHookConfig(MoETransformerObserverConfig):
+    module_class_name_to_hook_regex: Optional[str] = "Qwen3_5MoeSparseMoeBlock"
+    num_experts_attr_name: str = "experts.num_experts"
+    top_k_attr_name: str = "gate.top_k"
+    fused_experts: bool = True
+
+
 OBSERVER_CONFIG_REGISTRY = {
     "Qwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
     "NonUniformQwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
@@ -533,4 +545,6 @@ OBSERVER_CONFIG_REGISTRY = {
     "Ernie4_5_MoEForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Ernie4_5_MoeForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Glm4MoeForCausalLM": Glm44MoEObserverHookConfig,
+    "Qwen3_5MoeForConditionalGeneration": Qwen3_5MoEObserverHookConfig,
+    "Qwen3_5MoeForCausalLM": Qwen3_5MoEObserverHookConfig,
 }

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -40,6 +40,40 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+# Local addition: extracted from prune()'s inline body so it's reusable without an
+# already-loaded model -- el_prune_disk_surgery.py calls this directly to compute
+# retained expert indices per layer, then does its own disk-native tensor surgery
+# (no in-memory model instantiation) rather than going through prune()'s
+# in-memory model mutation + save_pretrained path below.
+def select_retained_experts(
+    observer_data, layer, prune_args, n_experts_to_prune, device="cpu"
+) -> list[int]:
+    """Return the sorted list of expert indices to KEEP for one layer, using the
+    same saliency criterion / top-k-least-salient selection as prune()."""
+    num_experts = observer_data[layer]["expert_frequency"].shape[0]
+    if prune_args.prune_method == "ean_ca":
+        ean = torch.zeros(num_experts, device=device, dtype=torch.float32)
+        for i in range(num_experts):
+            ean[i] = torch.linalg.norm(
+                observer_data[layer]["routed_characteristic_activation"][i], dim=-1
+            ).sum()
+        _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
+    else:
+        prune_method = prune_args.prune_method
+        if prune_method == "frequency":
+            prune_method = "expert_frequency"
+        saliency_data = observer_data[layer].get(prune_method)
+        if saliency_data is None:
+            raise ValueError(
+                f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
+                f"Available keys: {list(observer_data[layer].keys())}"
+            )
+        _, experts_to_prune = torch.topk(saliency_data, n_experts_to_prune, largest=False)
+
+    experts_to_prune = set(experts_to_prune.tolist())
+    return [i for i in range(num_experts) if i not in experts_to_prune]
+
+
 def prune(
     observer_data,
     model,
@@ -80,31 +114,10 @@ def prune(
                         observer_data[layer][metric][super_experts_in_layer] = float("inf")
 
     for layer in tqdm(observer_data, "Pruning layers..."):
-        num_experts = observer_data[layer]["expert_frequency"].shape[0]
-        if prune_args.prune_method == "ean_ca":
-            ean = torch.zeros(num_experts, device=model.device, dtype=torch.float32)
-            for i in range(num_experts):
-                ean[i] = torch.linalg.norm(
-                    observer_data[layer]["routed_characteristic_activation"][i], dim=-1
-                ).sum()
-            _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
-        else:
-            prune_method = prune_args.prune_method
-            if prune_method == "frequency":
-                prune_method = "expert_frequency"
-            saliency_data = observer_data[layer].get(prune_method)
-            if saliency_data is None:
-                raise ValueError(
-                    f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
-                    f"Available keys: {list(observer_data[layer].keys())}"
-                )
-            _, experts_to_prune = torch.topk(
-                saliency_data, n_experts_to_prune, largest=False
-            )
-
-        retained_expert_indicies = [
-            i for i in range(num_experts) if i not in experts_to_prune
-        ]
+        retained_expert_indicies = select_retained_experts(
+            observer_data, layer, prune_args, n_experts_to_prune,
+            device=model.device,
+        )
         # prune experts
         moe = get_moe(model, layer)
         if not model_attrs["fused"]:
@@ -133,16 +146,26 @@ def prune(
                 )
             setattr(moe, model_attrs["router"], router)
         else:
-            # prune fused experts, only tested for llama-4
+            # prune fused experts. Originally only tested for llama-4 (hardcoded
+            # `moe.router`, assumed nn.Linear with `out_features`); generalized here
+            # to go through model_attrs["router"] and to tolerate routers that are
+            # raw weight Parameters without `out_features` (e.g. Qwen3.5's
+            # Qwen3_5MoeTopKRouter).
             moe.experts.gate_up_proj.data = moe.experts.gate_up_proj[
                 retained_expert_indicies
             ]
             moe.experts.down_proj.data = moe.experts.down_proj[retained_expert_indicies]
-            moe.num_experts = len(retained_expert_indicies)
-            moe.router.weight.data = moe.router.weight.data[retained_expert_indicies]
-            moe.router.out_features = len(retained_expert_indicies)
-            if hasattr(moe.router, "num_experts"):  # transformers >= 4.54+
-                moe.router.num_experts = len(retained_expert_indicies)
+            if hasattr(moe.experts, "num_experts"):
+                moe.experts.num_experts = len(retained_expert_indicies)
+            if hasattr(moe, "num_experts"):
+                moe.num_experts = len(retained_expert_indicies)
+            router = getattr(moe, model_attrs["router"])
+            router.weight.data = router.weight.data[retained_expert_indicies]
+            if hasattr(router, "out_features"):
+                router.out_features = len(retained_expert_indicies)
+            if hasattr(router, "num_experts"):  # transformers >= 4.54+
+                router.num_experts = len(retained_expert_indicies)
+            setattr(moe, model_attrs["router"], router)
 
     # patch config and dump
     logger.info("Saving pruned model...")


### PR DESCRIPTION
## Summary

Standalone, no dependency on other PRs in this stack.

Adds `GenericLMDataset`, a fallback `LMDatasetProcessor` for local plain-text datasets that aren't in `DATASET_REGISTRY`, so an arbitrary local jsonl/text calibration corpus can be used without registering a bespoke dataset entry first.