### PR TITLE
Add general MTP (multi-token-prediction head) pruning support

### DIFF
--- a/src/reap/disk_stream_util.py
+++ b/src/reap/disk_stream_util.py
@@ -1,0 +1,107 @@
+# Local addition (not upstream REAP): streams a checkpoint's real tensors from its
+# safetensors shards directly onto a target device, on demand, one module at a time.
+#
+# Used to make LayerwiseMoEObserver's block replay genuinely disk-streaming: the
+# model is constructed with meta-device weights (accelerate.init_empty_weights(),
+# ~0 RAM), and a block's real tensors are materialized here right before its
+# forward and released back to meta right after -- instead of REAP's original
+# approach of loading the entire model onto CPU via device_map="cpu" (~794GB of RAM
+# for a model like Ornith-1.0-397B, not available on hardware with far less RAM+VRAM
+# combined than the checkpoint size).
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict
+
+import torch
+import torch.nn as nn
+from accelerate.utils import set_module_tensor_to_device
+from safetensors import safe_open
+
+logger = logging.getLogger(__name__)
+
+
+class SafetensorsIndex:
+    """Lazy, mmap-backed access to a checkpoint's tensors by name.
+
+    Deliberately does NOT cache open safe_open() handles across calls: mmap'd pages
+    stay resident (counted in RSS) for as long as the mapping is open, even after
+    the torch tensor copied out of them is freed. For a checkpoint far larger than
+    available RAM, caching handles indefinitely would silently re-create the exact
+    problem this module exists to avoid (RSS creeping up by however much of the
+    file has been touched so far, instead of staying bounded to one block at a
+    time). Every read (or batch of reads via read_tensors) opens a shard, reads,
+    and closes/unmaps before returning.
+    """
+
+    def __init__(self, checkpoint_dir: str):
+        self.checkpoint_dir = Path(checkpoint_dir)
+        index_path = self.checkpoint_dir / "model.safetensors.index.json"
+        if index_path.exists():
+            with open(index_path) as f:
+                self.weight_map: Dict[str, str] = json.load(f)["weight_map"]
+        else:
+            # Small, unsharded checkpoint: one model.safetensors file.
+            single_file = self.checkpoint_dir / "model.safetensors"
+            with safe_open(str(single_file), framework="pt") as f:
+                self.weight_map = {name: single_file.name for name in f.keys()}
+
+    def has_tensor(self, name: str) -> bool:
+        return name in self.weight_map
+
+    def read_tensor(self, name: str, device: str = "cpu") -> torch.Tensor:
+        return self.read_tensors([name], device=device)[name]
+
+    def read_tensors(self, names: list[str], device: str = "cpu") -> Dict[str, torch.Tensor]:
+        """Read several tensors, grouped by shard file so each shard is opened and
+        closed (unmapped) once regardless of how many tensors are pulled from it."""
+        by_shard: Dict[str, list[str]] = {}
+        for name in names:
+            by_shard.setdefault(self.weight_map[name], []).append(name)
+
+        result: Dict[str, torch.Tensor] = {}
+        for shard_name, shard_tensor_names in by_shard.items():
+            with safe_open(str(self.checkpoint_dir / shard_name), framework="pt") as f:
+                for name in shard_tensor_names:
+                    tensor = f.get_tensor(name)
+                    if device != "cpu":
+                        tensor = tensor.to(device)
+                    result[name] = tensor
+        return result
+
+    def tensor_names_with_prefix(self, prefix: str) -> list[str]:
+        dotted = prefix if prefix.endswith(".") else prefix + "."
+        return [n for n in self.weight_map if n == prefix or n.startswith(dotted)]
+
+
+def materialize_module(
+    module: nn.Module, module_name: str, index: SafetensorsIndex, device: str
+) -> None:
+    """Populate `module`'s (currently meta) parameters/buffers with real data read
+    directly from the checkpoint, onto `device`. `module_name` is `module`'s dotted
+    path in the full model (used as the tensor-name prefix in the checkpoint)."""
+    targets = []  # (param_name, full_checkpoint_name)
+    for name, tensor in list(module.named_parameters()) + list(module.named_buffers()):
+        if str(tensor.device) != "meta":
+            continue  # already materialized (e.g. shared/tied weights)
+        full_name = f"{module_name}.{name}"
+        if not index.has_tensor(full_name):
+            logger.warning("No checkpoint tensor found for %s, leaving on meta", full_name)
+            continue
+        targets.append((name, full_name))
+
+    if not targets:
+        return
+    values = index.read_tensors([full_name for _, full_name in targets], device=device)
+    for name, full_name in targets:
+        set_module_tensor_to_device(module, name, device, value=values[full_name])
+
+
+def free_module(module: nn.Module) -> None:
+    """Release a module's real tensors back to the meta device, freeing memory."""
+    for name, tensor in list(module.named_parameters()) + list(module.named_buffers()):
+        if str(tensor.device) == "meta":
+            continue
+        set_module_tensor_to_device(module, name, "meta")

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -219,6 +219,19 @@ class LayerwiseMoEObserver:
         # State dictionary to store metrics per block
         self.state: Dict[int, Dict[str, Any]] = {}
 
+        # Local addition: for models with an MTP (multi-token-prediction) head that
+        # reuses the main model's global expert count, the MTP layer needs its own
+        # saliency pass fed with real final-hidden-state / mask / position inputs.
+        # Rather than re-deriving those (RoPE, causal mask, etc.) by hand, capture
+        # exactly what the *last* main block actually received and produced -- since
+        # MTP's decoder layer has the same layer_type ("full_attention") and config
+        # as the model's own last full_attention block, this is directly reusable.
+        # Populated by _forward_block for block_idx == len(self.blocks) - 1 only;
+        # consumed by reap.mtp_util after record_all_blocks() completes and before
+        # replay_cache.clear() would otherwise discard it.
+        self.final_hidden_states: List[torch.Tensor] = []
+        self.final_block_kwargs: List[Dict[str, Any]] = []
+
         # MoE module cache per block
         self._moe_modules_cache: Dict[int, Optional[nn.Module]] = {}
 
@@ -895,6 +908,19 @@ class LayerwiseMoEObserver:
 
                 if after_forward is not None:
                     after_forward(target_device, attention_mask)
+
+                # Local addition: this is the model's actual last block -- stash its
+                # real inputs/output (moved to CPU) for a possible later MTP saliency
+                # pass. See the final_hidden_states/final_block_kwargs docstring in
+                # __init__ for why this reuse is architecturally valid.
+                if block_idx == len(self.blocks) - 1:
+                    self.final_hidden_states.append(hidden_states.detach().cpu())
+                    self.final_block_kwargs.append(
+                        {
+                            key: move_to_device(value, torch.device("cpu"))
+                            for key, value in block_kwargs.items()
+                        }
+                    )
 
                 block_outputs.append([hidden_states.detach().cpu()])
 

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -24,6 +24,7 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 from transformers.tokenization_utils_base import BatchEncoding
+from transformers.masking_utils import create_causal_mask
 
 from reap.observer import (
     MoETransformerObserverConfig,
@@ -39,6 +40,7 @@ from reap.layerwise_model_utils import (
 )
 from reap.pruning_metrics import initialize_pruning_state, update_pruning_state
 from reap.metrics import OnlineStatsTracker
+from reap.disk_stream_util import SafetensorsIndex, materialize_module, free_module
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -56,6 +58,15 @@ class ReplayBatch:
     kwargs: Dict[str, Any]
     attention_mask: Optional[torch.Tensor] = None
     position_ids: Optional[torch.Tensor] = None
+    # Local addition: hybrid-attention models (e.g. Qwen3.5's mix of
+    # linear_attention/full_attention layers) compute a *different* mask per layer
+    # type -- `attention_mask` above is whatever mask block 0's own layer_type
+    # received (e.g. the raw/linear mask if block 0 is linear_attention), which is
+    # wrong to replay verbatim into a later full_attention block. `causal_mask` is
+    # the properly-constructed causal mask for full_attention layers, computed once
+    # alongside the rest of block 0's captured inputs; the right one is selected per
+    # block by layer_type at replay time (see _forward_block).
+    causal_mask: Optional[torch.Tensor] = None
 
 
 class ReplayCache:
@@ -73,6 +84,7 @@ class ReplayCache:
         kwargs: Dict[str, Any],
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        causal_mask: Optional[torch.Tensor] = None,
     ) -> None:
         self._batches.append(
             ReplayBatch(
@@ -80,6 +92,7 @@ class ReplayCache:
                 kwargs=kwargs,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
+                causal_mask=causal_mask,
             )
         )
 
@@ -110,6 +123,12 @@ class ReplayCache:
         if batch.position_ids is not None:
             replay_kwargs["position_ids"] = move_to_device(
                 batch.position_ids, target_device
+            )
+        if batch.causal_mask is not None:
+            # Internal-only key, consumed and stripped in _forward_block's per-block
+            # mask selection -- never passed to a block's forward directly.
+            replay_kwargs["_causal_mask"] = move_to_device(
+                batch.causal_mask, target_device
             )
 
         return replay_inputs, replay_kwargs
@@ -158,6 +177,7 @@ class LayerwiseMoEObserver:
         model: nn.Module,
         hook_config: MoETransformerObserverConfig,
         block_names: Optional[List[str]] = None,
+        disk_index: Optional[SafetensorsIndex] = None,
     ):
         """
         Initialize the layerwise (blockwise) MoE observer.
@@ -166,9 +186,17 @@ class LayerwiseMoEObserver:
             model: The PyTorch MoE model to observe
             hook_config: Configuration for hooks (contains MoE-specific settings)
             block_names: List of transformer block names. Auto-detected if None.
+            disk_index: Local addition. When given, blocks with meta-device
+                parameters (i.e. the model was constructed with
+                accelerate.init_empty_weights() rather than fully materialized via
+                device_map="cpu") are streamed in from the checkpoint's safetensors
+                shards on demand -- materialized right before their forward and
+                released back to meta right after -- instead of requiring the whole
+                model resident in RAM up front. See disk_stream_util.py.
         """
         self.model = model
         self.hook_config = hook_config
+        self.disk_index = disk_index
         self._memory_cleanup_freq = 4
 
         # Auto-detect decoder blocks if not provided
@@ -249,6 +277,18 @@ class LayerwiseMoEObserver:
         """
         try:
             if has_meta_tensors(block):
+                if self.disk_index is not None and device != "meta":
+                    # Local addition: this block was constructed on the meta
+                    # device (init_empty_weights) rather than fully materialized
+                    # via device_map="cpu" -- stream its real tensors in from the
+                    # checkpoint directly onto the target device.
+                    materialize_module(
+                        block, self.block_names[block_idx], self.disk_index, device
+                    )
+                    logger.debug(
+                        "Materialized block %s from disk onto %s", block_idx, device
+                    )
+                    return safe_get_device(block)
                 logger.debug(
                     "Block %s has meta tensors, skipping move to %s",
                     block_idx,
@@ -294,16 +334,20 @@ class LayerwiseMoEObserver:
         return final_device
 
     def _offload_current_block(self) -> None:
-        """Offload the current block to CPU and release memory."""
+        """Offload the current block to CPU and release memory. When disk-streaming
+        (see disk_index), offloads all the way to meta instead of cpu, so the real
+        tensors are actually freed rather than accumulating in system RAM -- the
+        block gets re-materialized from disk next time it's needed."""
         block_idx = self.currently_loaded_block_idx
         if block_idx < 0:
             return
 
         block = self._block_at(block_idx)
+        offload_device = "meta" if self.disk_index is not None else "cpu"
 
         try:
             if block is not None:
-                self._move_block(block, block_idx, "cpu")
+                self._move_block(block, block_idx, offload_device)
         finally:
             self.currently_loaded_block_idx = -1
             cleanup_memory(synchronize=False)
@@ -468,6 +512,26 @@ class LayerwiseMoEObserver:
                     continue
                 replay_kwargs[key] = move_to_device(value, cpu_device)
 
+            # Local addition: hybrid-attention models (Qwen3.5) compute a separate
+            # causal mask for full_attention layers, distinct from whatever mask
+            # block 0 (possibly a linear_attention layer) received above. Compute it
+            # the same way the real model forward does, so later full_attention
+            # blocks get the right mask at replay time instead of block 0's.
+            causal_mask = None
+            hidden_states_value = args[0] if args else kwargs.get("hidden_states")
+            if torch.is_tensor(hidden_states_value):
+                try:
+                    text_config = LayerwiseMoEObserver._resolve_text_config(self.model)
+                    causal_mask = create_causal_mask(
+                        config=text_config,
+                        inputs_embeds=hidden_states_value,
+                        attention_mask=attention_mask,
+                        past_key_values=None,
+                        position_ids=position_ids,
+                    )
+                except Exception as exc:
+                    logger.debug("Could not precompute a causal_mask for replay: %s", exc)
+
             captured_batches.append(
                 ReplayBatch(
                     inputs=replay_inputs,
@@ -479,6 +543,9 @@ class LayerwiseMoEObserver:
                     else None,
                     position_ids=position_ids.detach().cpu()
                     if torch.is_tensor(position_ids)
+                    else None,
+                    causal_mask=causal_mask.detach().cpu()
+                    if torch.is_tensor(causal_mask)
                     else None,
                 )
             )
@@ -505,6 +572,7 @@ class LayerwiseMoEObserver:
                 kwargs=batch.kwargs,
                 attention_mask=batch.attention_mask,
                 position_ids=batch.position_ids,
+                causal_mask=batch.causal_mask,
             )
 
         logger.info("Prepared replay cache for %s batches", len(self.replay_cache))
@@ -521,6 +589,15 @@ class LayerwiseMoEObserver:
                 continue
             sanitized[key] = value
         return sanitized
+
+    @staticmethod
+    def _resolve_text_config(model: nn.Module):
+        """Local addition: find the text-only config a decoder layer's masking
+        logic was built against, for models where the top-level config wraps a
+        separate text_config (e.g. multimodal Qwen3.5 wrappers)."""
+        inner = getattr(model, "model", model)
+        text_module = getattr(inner, "language_model", inner)
+        return getattr(text_module, "config", model.config)
 
     def _get_forward_signature_info(self, block_idx: int) -> Tuple[set[str], bool]:
         """Return accepted forward kwargs and whether the block accepts **kwargs."""
@@ -660,8 +737,24 @@ class LayerwiseMoEObserver:
             return router_logits
 
         if self.hook_config.fused_experts:
-            # Fused experts (e.g., Llama-4)
-            router_logits = extract_router_logits(moe_module.router, flat_input)
+            # Fused experts (e.g., Llama-4, Qwen3.5).
+            # Local addition: Qwen3.5's router (`gate`) returns
+            # (router_logits, router_scores, router_indices) -- logits *first*,
+            # unlike REAP's generic extract_router_logits(), which assumes the
+            # logits are the *last* element of a returned tuple. Normalize via a
+            # thin wrapper instead of touching that shared helper (other models
+            # rely on its convention).
+            router_module = getattr(moe_module, "router", None)
+            if router_module is None and hasattr(moe_module, "gate"):
+                gate_module = moe_module.gate
+
+                def router_module(x):
+                    result = gate_module(x)
+                    return result[0] if isinstance(result, tuple) else result
+            if router_module is None:
+                raise ValueError(f"Cannot find router in MoE module at block {block_idx}")
+
+            router_logits = extract_router_logits(router_module, flat_input)
             _, selected_experts = torch.topk(router_logits, top_k, dim=-1)
             selected_experts = selected_experts.to(device)
 
@@ -676,8 +769,26 @@ class LayerwiseMoEObserver:
                 dim=0,
                 index=router_indices,
             ).to(device)
-            routed_out = moe_module.experts(routed_in)
-            activations = routed_out.view(num_experts, *flat_input.shape)
+            try:
+                # Llama4-style fused experts: forward(hidden_states) accepts an
+                # (num_experts * tokens, hidden) tensor directly.
+                routed_out = moe_module.experts(routed_in)
+                activations = routed_out.view(num_experts, *flat_input.shape)
+            except TypeError:
+                # Qwen3.5-style fused experts (Qwen3_5MoeExperts.forward requires
+                # top_k_index/top_k_weights for sparse dispatch -- no dense
+                # all-experts-all-tokens calling convention exists). Compute the
+                # dense (num_experts, tokens, hidden) activations directly from the
+                # raw fused weight tensors instead.
+                experts_module = moe_module.experts
+                gate_up = torch.einsum(
+                    "th,eoh->eto", flat_input, experts_module.gate_up_proj
+                )
+                gate, up = gate_up.chunk(2, dim=-1)
+                hidden = experts_module.act_fn(gate) * up
+                activations = torch.einsum(
+                    "eti,eoi->eto", hidden, experts_module.down_proj
+                )
         else:
             # Loop-based MoE execution
             # First, we need to get router logits by doing a forward pass
@@ -760,6 +871,14 @@ class LayerwiseMoEObserver:
                     batch_idx=batch_idx,
                     target_device=target_device,
                 )
+                # Local addition: hybrid-attention models need a different mask per
+                # layer type (see ReplayBatch.causal_mask) -- swap in the properly
+                # computed causal mask for full_attention blocks; leave whatever
+                # mask was captured (e.g. the raw/linear mask) for everything else.
+                causal_mask = block_kwargs.pop("_causal_mask", None)
+                if causal_mask is not None and getattr(block, "layer_type", None) == "full_attention":
+                    block_kwargs["attention_mask"] = causal_mask
+
                 attention_mask = block_kwargs.get("attention_mask", None)
 
                 block_kwargs = self._build_replay_kwargs(block_idx, block_kwargs)

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -269,6 +269,32 @@ def record_activations_layerwise(
 
     logger.info(f"Layerwise activation recording complete. Saved to {output_file}")
 
+    # Local addition: if this checkpoint has an MTP (multi-token-prediction) head
+    # (mtp.* tensors -- not every checkpoint using this architecture ships them, see
+    # reap/mtp_util.py), also persist what reap.mtp_util needs to run MTP's own
+    # saliency pass later: the real final-hidden-state / mask / position inputs the
+    # model's actual last block received and produced, captured on the observer
+    # during record_all_blocks above (see layerwise_observer.py's
+    # final_hidden_states/final_block_kwargs).
+    if disk_index is not None and any(
+        name.startswith("mtp.") for name in disk_index.weight_map
+    ):
+        mtp_replay_file = output_file.parent / f"mtp_replay_{output_file.name}"
+        torch.save(
+            {
+                "final_hidden_states": observer.final_hidden_states,
+                "final_block_kwargs": observer.final_block_kwargs,
+                # Raw tokenized calibration batches, needed to look up each
+                # position's actual next-token id (the teacher-forcing target MTP's
+                # predictor combines with the final hidden state). Not otherwise
+                # recoverable from the observer -- data_batches never reaches
+                # LayerwiseMoEObserver in tokenized form beyond seeding block 0.
+                "input_ids_batches": data_batches,
+            },
+            mtp_replay_file,
+        )
+        logger.info(f"Saved MTP replay inputs to {mtp_replay_file}")
+
     return observer_data
 
 

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -28,8 +28,12 @@ import hashlib
 from typing import Any, Dict, List
 import yaml
 
+import pathlib as _pathlib
+
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, HfArgumentParser
+import transformers
+from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM, HfArgumentParser
+from accelerate import init_empty_weights
 
 from accelerate.utils import set_seed
 
@@ -48,10 +52,64 @@ from reap.model_util import patched_model_map
 from reap.observer import OBSERVER_CONFIG_REGISTRY
 from reap.layerwise_observer import LayerwiseMoEObserver
 from reap.layerwise_model_utils import cleanup_memory
+from reap.disk_stream_util import SafetensorsIndex, materialize_module
 from reap.eval import run_evaluate
 from reap.prune import prune as prune_model
 from reap.prune import get_pruned_model_dir
 from reap.main import dump_args_to_yaml, create_results_directory
+
+
+def _is_local_checkpoint_dir(model_name: str) -> bool:
+    """Local addition: True when model_name is a local directory with a safetensors
+    checkpoint on disk (our disk-streaming path applies here), as opposed to a
+    HuggingFace Hub model id (where the original device_map="cpu" full-RAM load is
+    kept, since REAP's other supported models are small enough for that to be fine)."""
+    path = _pathlib.Path(model_name)
+    return path.is_dir() and (
+        (path / "model.safetensors.index.json").exists()
+        or (path / "model.safetensors").exists()
+    )
+
+
+def _load_model_for_layerwise_processing(model_name: str, layerwise_args: "LayerwiseArgs"):
+    """Local addition: for local checkpoints, build the model on the meta device
+    (accelerate.init_empty_weights(), ~0 RAM) and materialize only the embedding
+    table for real, instead of device_map="cpu" (which materializes the *entire*
+    checkpoint in RAM -- infeasible for models much larger than available RAM+VRAM
+    combined). Each decoder block's real weights are streamed in from disk on
+    demand by LayerwiseMoEObserver (see disk_stream_util.py), one block at a time.
+    Returns (model, disk_index_or_None)."""
+    if not _is_local_checkpoint_dir(model_name):
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            device_map="cpu",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            low_cpu_mem_usage=layerwise_args.low_cpu_mem_usage,
+        )
+        return model, None
+
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    archs = getattr(config, "architectures", None)
+    model_cls = getattr(transformers, archs[0], None) if archs else None
+
+    with init_empty_weights():
+        if model_cls is not None:
+            model = model_cls(config)
+        else:
+            model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+
+    disk_index = SafetensorsIndex(model_name)
+
+    text_model = model.model.language_model if hasattr(model.model, "language_model") else model.model
+    embed_prefix = (
+        "model.language_model.embed_tokens"
+        if hasattr(model.model, "language_model")
+        else "model.embed_tokens"
+    )
+    materialize_module(text_model.embed_tokens, embed_prefix, disk_index, device="cpu")
+
+    return model, disk_index
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -153,6 +211,7 @@ def record_activations_layerwise(
     obs_args: ObserverArgs,
     layerwise_args: LayerwiseArgs,
     results_dir: pathlib.Path,
+    disk_index: "SafetensorsIndex | None" = None,
 ) -> Dict[int, Dict[str, Any]]:
     """
     Record MoE activations using layerwise processing.
@@ -179,6 +238,7 @@ def record_activations_layerwise(
     observer = LayerwiseMoEObserver(
         model=model,
         hook_config=hook_config,
+        disk_index=disk_index,
     )
 
     # Process all blocks
@@ -277,15 +337,11 @@ def main():
         logger.info("Preparing calibration samples...")
         data_batches = prepare_calibration_batches(tokenizer, ds_args, obs_args)
 
-        # Load model on CPU for layerwise processing
-        logger.info(f"Loading model {model_name} on CPU for layerwise processing...")
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            device_map="cpu",
-            torch_dtype="auto",
-            trust_remote_code=True,
-            low_cpu_mem_usage=layerwise_args.low_cpu_mem_usage,
-        )
+        # Load model for layerwise processing (disk-streamed for local checkpoints
+        # too large to fit in RAM; device_map="cpu" full load otherwise -- see
+        # _load_model_for_layerwise_processing)
+        logger.info(f"Loading model {model_name} for layerwise processing...")
+        model, disk_index = _load_model_for_layerwise_processing(model_name, layerwise_args)
         model.eval()
 
         logger.info(f"Model loaded: {model.__class__.__name__}")
@@ -307,6 +363,7 @@ def main():
                 obs_args,
                 layerwise_args,
                 results_dir,
+                disk_index=disk_index,
             )
 
     if reap_args.run_observer_only:

--- a/src/reap/model_util.py
+++ b/src/reap/model_util.py
@@ -115,12 +115,33 @@ MODEL_ATTRS = {
         "num_experts": "n_routed_experts",
         "num_experts_per_tok": "num_experts_per_tok",
     },
+    # Local addition: not yet in upstream REAP. Qwen3_5MoeExperts stores experts as
+    # fused 3D parameter tensors (gate_up_proj, down_proj), same shape as Llama4's
+    # fused MoE layer above -- reuses that code path via fused=True. shared_expert is
+    # a separate always-on MLP outside this registry and is untouched by pruning.
+    "Qwen3_5MoeForConditionalGeneration": {
+        "moe_block": "mlp",
+        "gate_proj": "gate_up_proj",
+        "up_proj": "gate_up_proj",
+        "down_proj": "down_proj",
+        "experts": "experts",
+        "fused": True,
+        "router": "gate",
+        "num_experts": "num_experts",
+        "num_experts_per_tok": "num_experts_per_tok",
+    },
 }
 
 
 def get_moe(model, layer):
     moe_attr_name = MODEL_ATTRS.get(model.__class__.__name__)["moe_block"]
-    return getattr(model.model.layers[layer], moe_attr_name)
+    # Local addition: Qwen3_5MoeForConditionalGeneration nests decoder layers one
+    # level deeper (model.model.language_model.layers) than the causal-LM-only
+    # classes this originally targeted (model.model.layers).
+    decoder = model.model
+    if hasattr(decoder, "language_model"):
+        decoder = decoder.language_model
+    return getattr(decoder.layers[layer], moe_attr_name)
 
 
 def assert_merge(model, merged_moe, cluster_label):

--- a/src/reap/mtp_util.py
+++ b/src/reap/mtp_util.py
@@ -1,0 +1,249 @@
+"""
+Local addition -- no upstream equivalent.
+
+MTP (multi-token-prediction / speculative-decoding head) support for expert
+pruning. Some checkpoints of this architecture ship an extra `mtp.*` decoder layer
+plus a small "predictor" module (a norm + linear combining the model's final
+hidden state with the actual next-token embedding). It shares the main model's
+global expert count (`config.num_experts`) but has an INDEPENDENTLY LEARNED router
+and expert pool -- pruning it correctly means giving it its own saliency pass, not
+reusing the main model's retained-expert indices or leaving it untouched with a
+stale expert count.
+
+Not every checkpoint of this architecture ships this head. Every public function
+here is a no-op or returns False when `mtp.*` tensors aren't present in the
+checkpoint's index, so callers (el_prune.py / el_prune_disk_surgery.py) can call
+this unconditionally without needing to know ahead of time whether a given
+checkpoint has MTP.
+
+Design note: rather than hand-implement MTP's self-attention (RoPE, GQA, causal
+masking), this builds a REAL `Qwen3_5MoeDecoderLayer` from `transformers` (the same
+class the main model's own full_attention blocks use) and feeds it the exact
+attention_mask/position_ids/position_embeddings the model's own last full_attention
+block actually received (captured during the main calibration run -- see
+layerwise_observer.py's final_hidden_states/final_block_kwargs and
+layerwise_prune.py's mtp_replay_*.pt output). This is valid because MTP's layer has
+the same layer_type ("full_attention") and config as that block, and per-position
+RoPE/mask metadata doesn't depend on which specific full_attention layer receives
+it. The only genuinely new math here is the small "predictor" combination step
+(pre_fc_norm_hidden/pre_fc_norm_embedding/fc) and the unfused-per-expert-file ->
+fused-3D-tensor conversion for MTP's own expert pool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from reap.disk_stream_util import SafetensorsIndex
+from reap.layerwise_observer import LayerwiseMoEObserver
+
+logger = logging.getLogger(__name__)
+
+MTP_PREFIX = "mtp."
+MTP_LAYER_PREFIX = "mtp.layers.0."
+
+
+def has_mtp(disk_index: SafetensorsIndex) -> bool:
+    return any(name.startswith(MTP_PREFIX) for name in disk_index.weight_map)
+
+
+def _extract_input_ids(batch: Any) -> torch.Tensor:
+    """Mirrors layerwise_observer.py's _capture_first_block_inputs input handling
+    -- data_batches elements are either a raw input_ids tensor or a dict/BatchEncoding
+    with an "input_ids" key."""
+    if isinstance(batch, torch.Tensor):
+        return batch.unsqueeze(0) if batch.dim() == 1 else batch
+    if hasattr(batch, "items"):
+        tensor = batch["input_ids"]
+        return tensor.unsqueeze(0) if tensor.dim() == 1 else tensor
+    raise ValueError(f"Unsupported calibration batch type: {type(batch)}")
+
+
+def build_mtp_layer(
+    text_config, disk_index: SafetensorsIndex, device: str = "cpu", dtype: torch.dtype = torch.bfloat16
+) -> nn.Module:
+    """Build a real Qwen3_5MoeDecoderLayer with MTP's actual weights loaded.
+
+    Instantiated at layer_idx = last index of config.layer_types, since MTP's layer
+    is documented (vLLM's Qwen3_5MultiTokenPredictor) to be a full_attention layer
+    like the model's own final block -- this gives the right submodule shapes
+    (self_attn, not linear_attn) for free rather than hardcoding attention dims.
+    """
+    import transformers.models.qwen3_5_moe.modeling_qwen3_5_moe as qwen3_5_modeling
+
+    last_layer_idx = len(text_config.layer_types) - 1
+    if text_config.layer_types[last_layer_idx] != "full_attention":
+        raise ValueError(
+            f"Expected the model's last layer_type to be 'full_attention' (MTP's "
+            f"documented layer type) but got '{text_config.layer_types[last_layer_idx]}' "
+            f"-- MTP layer construction assumptions may not hold for this checkpoint."
+        )
+
+    layer = qwen3_5_modeling.Qwen3_5MoeDecoderLayer(text_config, last_layer_idx)
+    layer = layer.to(device=device, dtype=dtype)
+
+    def load(name: str) -> torch.Tensor:
+        return disk_index.read_tensor(name).to(device=device, dtype=dtype)
+
+    state_dict: Dict[str, torch.Tensor] = {}
+    direct_names = [
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.weight",
+        "self_attn.o_proj.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+        "mlp.gate.weight",
+        "mlp.shared_expert.gate_proj.weight",
+        "mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight",
+        "mlp.shared_expert_gate.weight",
+    ]
+    for rel_name in direct_names:
+        full_name = MTP_LAYER_PREFIX + rel_name
+        if full_name in disk_index.weight_map:
+            state_dict[rel_name] = load(full_name)
+        else:
+            logger.warning(f"MTP tensor {full_name} not in checkpoint; leaving {rel_name} at init value")
+
+    num_experts = text_config.num_experts
+    gate_up_rows = []
+    down_rows = []
+    for expert_idx in range(num_experts):
+        gate_w = load(f"{MTP_LAYER_PREFIX}mlp.experts.{expert_idx}.gate_proj.weight")
+        up_w = load(f"{MTP_LAYER_PREFIX}mlp.experts.{expert_idx}.up_proj.weight")
+        down_w = load(f"{MTP_LAYER_PREFIX}mlp.experts.{expert_idx}.down_proj.weight")
+        gate_up_rows.append(torch.cat([gate_w, up_w], dim=0))
+        down_rows.append(down_w)
+    state_dict["mlp.experts.gate_up_proj"] = torch.stack(gate_up_rows, dim=0)
+    state_dict["mlp.experts.down_proj"] = torch.stack(down_rows, dim=0)
+
+    missing, unexpected = layer.load_state_dict(state_dict, strict=False)
+    if unexpected:
+        raise ValueError(f"Unexpected keys building MTP layer: {unexpected}")
+    if missing:
+        logger.warning(f"MTP layer left un-loaded (init/random) keys: {missing}")
+
+    return layer
+
+
+def build_predictor_weights(
+    disk_index: SafetensorsIndex, device: str = "cpu", dtype: torch.dtype = torch.bfloat16
+) -> Dict[str, torch.Tensor]:
+    def load(name: str) -> torch.Tensor:
+        return disk_index.read_tensor(name).to(device=device, dtype=dtype)
+
+    return {
+        "fc_weight": load("mtp.fc.weight"),
+        "pre_fc_norm_embedding_weight": load("mtp.pre_fc_norm_embedding.weight"),
+        "pre_fc_norm_hidden_weight": load("mtp.pre_fc_norm_hidden.weight"),
+    }
+
+
+def _rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Matches Qwen3_5MoeRMSNorm's forward exactly (float32 accumulation)."""
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    return weight * x.to(input_dtype)
+
+
+class _MTPModelWrapper(nn.Module):
+    """Minimal fake "model" whose module tree matches what
+    reap.layerwise_model_utils.extract_model_components looks for (a
+    `.model.language_model.layers` ModuleList of decoder blocks), so the real
+    LayerwiseMoEObserver machinery -- hooks, per-expert stat accumulation, block
+    replay -- can be reused unmodified for MTP's single layer instead of
+    duplicating that logic."""
+
+    def __init__(self, mtp_layer: nn.Module):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.language_model = nn.Module()
+        self.model.language_model.layers = nn.ModuleList([mtp_layer])
+
+
+def run_mtp_observer(
+    text_config,
+    disk_index: SafetensorsIndex,
+    mtp_replay_data: Dict[str, Any],
+    hook_config,
+    embed_tokens_weight: torch.Tensor,
+    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+) -> Dict[int, Dict[str, Any]]:
+    """Run MTP's own saliency pass and return observer-data in the same
+    {0: {"expert_frequency": ..., "reap": ..., ...}} shape reap.prune's
+    select_retained_experts expects (single "layer" 0 = MTP's one layer)."""
+    final_hidden_states: List[torch.Tensor] = mtp_replay_data["final_hidden_states"]
+    final_block_kwargs: List[Dict[str, Any]] = mtp_replay_data["final_block_kwargs"]
+    input_ids_batches: List[Any] = mtp_replay_data["input_ids_batches"]
+
+    if not (len(final_hidden_states) == len(final_block_kwargs) == len(input_ids_batches)):
+        raise ValueError(
+            f"mtp_replay_data batch counts disagree: "
+            f"{len(final_hidden_states)} hidden states, {len(final_block_kwargs)} kwargs, "
+            f"{len(input_ids_batches)} input_ids batches"
+        )
+
+    # REAP's own replay machinery runs the main model's calibration forward in
+    # float32 regardless of the checkpoint's storage dtype (RoPE cos/sin come back
+    # float32 and promote hidden_states through the chain) -- build the MTP layer
+    # and predictor weights in whatever dtype the captured replay data actually
+    # used, not the checkpoint's on-disk dtype, or every op mixing the two raises a
+    # dtype mismatch the moment RoPE or the attention mask touches a tensor.
+    replay_dtype = final_hidden_states[0].dtype
+
+    mtp_layer = build_mtp_layer(text_config, disk_index, device=device, dtype=replay_dtype)
+    predictor = build_predictor_weights(disk_index, device=device, dtype=replay_dtype)
+    embed_tokens_weight = embed_tokens_weight.to(device=device, dtype=replay_dtype)
+
+    fake_model = _MTPModelWrapper(mtp_layer)
+    observer = LayerwiseMoEObserver(model=fake_model, hook_config=hook_config, disk_index=None)
+
+    for hidden_states, block_kwargs, raw_batch in zip(
+        final_hidden_states, final_block_kwargs, input_ids_batches
+    ):
+        hidden_states = hidden_states.to(device=device, dtype=replay_dtype)
+        input_ids = _extract_input_ids(raw_batch).to(device)
+
+        # Teacher-forcing target: the actual next token at each position. There's
+        # no "next token" for the last position -- rather than slice every kwarg
+        # tensor (masks/position_ids/position_embeddings) down to seq_len-1, which
+        # is easy to get subtly wrong for arbitrary mask shapes, shift left and pad
+        # with a repeat of the last real token. This makes the final position's
+        # target technically wrong, but it's one out of a full sequence length of
+        # tokens aggregated across many calibration batches -- negligible for
+        # saliency statistics, and keeps every tensor's sequence length identical
+        # so the captured kwargs can be reused completely unmodified.
+        next_token_ids = torch.cat([input_ids[:, 1:], input_ids[:, -1:]], dim=1)
+        next_token_embed = nn.functional.embedding(next_token_ids, embed_tokens_weight)
+
+        norm_hidden = _rms_norm(
+            hidden_states, predictor["pre_fc_norm_hidden_weight"], text_config.rms_norm_eps
+        )
+        norm_embed = _rms_norm(
+            next_token_embed, predictor["pre_fc_norm_embedding_weight"], text_config.rms_norm_eps
+        )
+        fc_input = torch.cat([norm_embed, norm_hidden], dim=-1)
+        mtp_input_hidden_states = nn.functional.linear(fc_input, predictor["fc_weight"])
+
+        seed_kwargs = {
+            key: (value.to(device) if torch.is_tensor(value) else value)
+            for key, value in block_kwargs.items()
+        }
+        observer.replay_cache.append(inputs=[mtp_input_hidden_states], kwargs=seed_kwargs)
+
+    observer._record_activations_for_block(0, moe_module=mtp_layer.mlp)
+    observer.replay_cache.clear()
+
+    # report_state() finalizes any OnlineStatsTracker accumulators into plain
+    # tensors -- select_retained_experts (like the main model's own path) expects
+    # already-finalized saliency tensors, not the raw in-progress trackers.
+    return observer.report_state()

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -524,6 +524,18 @@ class Glm44MoEObserverHookConfig(MoETransformerObserverConfig):
     fused_experts: bool = False
 
 
+# Local addition: not yet in upstream REAP, mirrors Llama4MoEObserverHookConfig
+# since Qwen3_5MoeExperts is likewise fused (see model_util.py's MODEL_ATTRS patch).
+# Qwen3_5MoeSparseMoeBlock itself has no num_experts/top_k attrs -- they live on its
+# .experts and .gate submodules respectively.
+@dataclass
+class Qwen3_5MoEObserverHookConfig(MoETransformerObserverConfig):
+    module_class_name_to_hook_regex: Optional[str] = "Qwen3_5MoeSparseMoeBlock"
+    num_experts_attr_name: str = "experts.num_experts"
+    top_k_attr_name: str = "gate.top_k"
+    fused_experts: bool = True
+
+
 OBSERVER_CONFIG_REGISTRY = {
     "Qwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
     "NonUniformQwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
@@ -533,4 +545,6 @@ OBSERVER_CONFIG_REGISTRY = {
     "Ernie4_5_MoEForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Ernie4_5_MoeForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Glm4MoeForCausalLM": Glm44MoEObserverHookConfig,
+    "Qwen3_5MoeForConditionalGeneration": Qwen3_5MoEObserverHookConfig,
+    "Qwen3_5MoeForCausalLM": Qwen3_5MoEObserverHookConfig,
 }

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -40,6 +40,40 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+# Local addition: extracted from prune()'s inline body so it's reusable without an
+# already-loaded model -- el_prune_disk_surgery.py calls this directly to compute
+# retained expert indices per layer, then does its own disk-native tensor surgery
+# (no in-memory model instantiation) rather than going through prune()'s
+# in-memory model mutation + save_pretrained path below.
+def select_retained_experts(
+    observer_data, layer, prune_args, n_experts_to_prune, device="cpu"
+) -> list[int]:
+    """Return the sorted list of expert indices to KEEP for one layer, using the
+    same saliency criterion / top-k-least-salient selection as prune()."""
+    num_experts = observer_data[layer]["expert_frequency"].shape[0]
+    if prune_args.prune_method == "ean_ca":
+        ean = torch.zeros(num_experts, device=device, dtype=torch.float32)
+        for i in range(num_experts):
+            ean[i] = torch.linalg.norm(
+                observer_data[layer]["routed_characteristic_activation"][i], dim=-1
+            ).sum()
+        _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
+    else:
+        prune_method = prune_args.prune_method
+        if prune_method == "frequency":
+            prune_method = "expert_frequency"
+        saliency_data = observer_data[layer].get(prune_method)
+        if saliency_data is None:
+            raise ValueError(
+                f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
+                f"Available keys: {list(observer_data[layer].keys())}"
+            )
+        _, experts_to_prune = torch.topk(saliency_data, n_experts_to_prune, largest=False)
+
+    experts_to_prune = set(experts_to_prune.tolist())
+    return [i for i in range(num_experts) if i not in experts_to_prune]
+
+
 def prune(
     observer_data,
     model,
@@ -80,31 +114,10 @@ def prune(
                         observer_data[layer][metric][super_experts_in_layer] = float("inf")
 
     for layer in tqdm(observer_data, "Pruning layers..."):
-        num_experts = observer_data[layer]["expert_frequency"].shape[0]
-        if prune_args.prune_method == "ean_ca":
-            ean = torch.zeros(num_experts, device=model.device, dtype=torch.float32)
-            for i in range(num_experts):
-                ean[i] = torch.linalg.norm(
-                    observer_data[layer]["routed_characteristic_activation"][i], dim=-1
-                ).sum()
-            _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
-        else:
-            prune_method = prune_args.prune_method
-            if prune_method == "frequency":
-                prune_method = "expert_frequency"
-            saliency_data = observer_data[layer].get(prune_method)
-            if saliency_data is None:
-                raise ValueError(
-                    f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
-                    f"Available keys: {list(observer_data[layer].keys())}"
-                )
-            _, experts_to_prune = torch.topk(
-                saliency_data, n_experts_to_prune, largest=False
-            )
-
-        retained_expert_indicies = [
-            i for i in range(num_experts) if i not in experts_to_prune
-        ]
+        retained_expert_indicies = select_retained_experts(
+            observer_data, layer, prune_args, n_experts_to_prune,
+            device=model.device,
+        )
         # prune experts
         moe = get_moe(model, layer)
         if not model_attrs["fused"]:
@@ -133,16 +146,26 @@ def prune(
                 )
             setattr(moe, model_attrs["router"], router)
         else:
-            # prune fused experts, only tested for llama-4
+            # prune fused experts. Originally only tested for llama-4 (hardcoded
+            # `moe.router`, assumed nn.Linear with `out_features`); generalized here
+            # to go through model_attrs["router"] and to tolerate routers that are
+            # raw weight Parameters without `out_features` (e.g. Qwen3.5's
+            # Qwen3_5MoeTopKRouter).
             moe.experts.gate_up_proj.data = moe.experts.gate_up_proj[
                 retained_expert_indicies
             ]
             moe.experts.down_proj.data = moe.experts.down_proj[retained_expert_indicies]
-            moe.num_experts = len(retained_expert_indicies)
-            moe.router.weight.data = moe.router.weight.data[retained_expert_indicies]
-            moe.router.out_features = len(retained_expert_indicies)
-            if hasattr(moe.router, "num_experts"):  # transformers >= 4.54+
-                moe.router.num_experts = len(retained_expert_indicies)
+            if hasattr(moe.experts, "num_experts"):
+                moe.experts.num_experts = len(retained_expert_indicies)
+            if hasattr(moe, "num_experts"):
+                moe.num_experts = len(retained_expert_indicies)
+            router = getattr(moe, model_attrs["router"])
+            router.weight.data = router.weight.data[retained_expert_indicies]
+            if hasattr(router, "out_features"):
+                router.out_features = len(retained_expert_indicies)
+            if hasattr(router, "num_experts"):  # transformers >= 4.54+
+                router.num_experts = len(retained_expert_indicies)
+            setattr(moe, model_attrs["router"], router)
 
     # patch config and dump
     logger.info("Saving pruned model...")


### PR DESCRIPTION
## Summary

Depends on #26 (disk-streaming) — stacked on top of it, so the diff includes those commits until it merges; only the last commit is new here.

MTP heads share the main model's global expert count but have an independently learned router+expert pool, which the existing observer/pruning path doesn't touch at all.

## What's in this PR

- `src/reap/mtp_util.py` (new): builds a real `Qwen3_5MoeDecoderLayer` for MTP's saliency pass rather than reimplementing attention by hand.
- `src/reap/layerwise_observer.py` / `src/reap/layerwise_prune.py`: captures the real final-hidden-state/mask/position inputs the model's last block received, so MTP's saliency pass can replay them faithfully instead of recomputing RoPE/masks independently.

Automatically a no-op when a checkpoint doesn't ship an MTP head.

## Validation

Built a tiny synthetic checkpoint with real MTP tensors in the actual unfused per-expert-file layout and ran the full pipeline end-to-end: main-model observer → MTP replay capture → MTP's own saliency pass → combined disk-surgery pruning both pools consistently (same retained expert count, MTP experts renumbered sequentially with no gaps). Verified the "no MTP" case is a true no-op (falls through to the main-model-only path unchanged, no MTP-related file ever touched).