### PR TITLE
Force eager fused-experts dispatch for layerwise replay

### DIFF
--- a/src/reap/disk_stream_util.py
+++ b/src/reap/disk_stream_util.py
@@ -1,0 +1,107 @@
+# Local addition (not upstream REAP): streams a checkpoint's real tensors from its
+# safetensors shards directly onto a target device, on demand, one module at a time.
+#
+# Used to make LayerwiseMoEObserver's block replay genuinely disk-streaming: the
+# model is constructed with meta-device weights (accelerate.init_empty_weights(),
+# ~0 RAM), and a block's real tensors are materialized here right before its
+# forward and released back to meta right after -- instead of REAP's original
+# approach of loading the entire model onto CPU via device_map="cpu" (~794GB of RAM
+# for a model like Ornith-1.0-397B, not available on hardware with far less RAM+VRAM
+# combined than the checkpoint size).
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict
+
+import torch
+import torch.nn as nn
+from accelerate.utils import set_module_tensor_to_device
+from safetensors import safe_open
+
+logger = logging.getLogger(__name__)
+
+
+class SafetensorsIndex:
+    """Lazy, mmap-backed access to a checkpoint's tensors by name.
+
+    Deliberately does NOT cache open safe_open() handles across calls: mmap'd pages
+    stay resident (counted in RSS) for as long as the mapping is open, even after
+    the torch tensor copied out of them is freed. For a checkpoint far larger than
+    available RAM, caching handles indefinitely would silently re-create the exact
+    problem this module exists to avoid (RSS creeping up by however much of the
+    file has been touched so far, instead of staying bounded to one block at a
+    time). Every read (or batch of reads via read_tensors) opens a shard, reads,
+    and closes/unmaps before returning.
+    """
+
+    def __init__(self, checkpoint_dir: str):
+        self.checkpoint_dir = Path(checkpoint_dir)
+        index_path = self.checkpoint_dir / "model.safetensors.index.json"
+        if index_path.exists():
+            with open(index_path) as f:
+                self.weight_map: Dict[str, str] = json.load(f)["weight_map"]
+        else:
+            # Small, unsharded checkpoint: one model.safetensors file.
+            single_file = self.checkpoint_dir / "model.safetensors"
+            with safe_open(str(single_file), framework="pt") as f:
+                self.weight_map = {name: single_file.name for name in f.keys()}
+
+    def has_tensor(self, name: str) -> bool:
+        return name in self.weight_map
+
+    def read_tensor(self, name: str, device: str = "cpu") -> torch.Tensor:
+        return self.read_tensors([name], device=device)[name]
+
+    def read_tensors(self, names: list[str], device: str = "cpu") -> Dict[str, torch.Tensor]:
+        """Read several tensors, grouped by shard file so each shard is opened and
+        closed (unmapped) once regardless of how many tensors are pulled from it."""
+        by_shard: Dict[str, list[str]] = {}
+        for name in names:
+            by_shard.setdefault(self.weight_map[name], []).append(name)
+
+        result: Dict[str, torch.Tensor] = {}
+        for shard_name, shard_tensor_names in by_shard.items():
+            with safe_open(str(self.checkpoint_dir / shard_name), framework="pt") as f:
+                for name in shard_tensor_names:
+                    tensor = f.get_tensor(name)
+                    if device != "cpu":
+                        tensor = tensor.to(device)
+                    result[name] = tensor
+        return result
+
+    def tensor_names_with_prefix(self, prefix: str) -> list[str]:
+        dotted = prefix if prefix.endswith(".") else prefix + "."
+        return [n for n in self.weight_map if n == prefix or n.startswith(dotted)]
+
+
+def materialize_module(
+    module: nn.Module, module_name: str, index: SafetensorsIndex, device: str
+) -> None:
+    """Populate `module`'s (currently meta) parameters/buffers with real data read
+    directly from the checkpoint, onto `device`. `module_name` is `module`'s dotted
+    path in the full model (used as the tensor-name prefix in the checkpoint)."""
+    targets = []  # (param_name, full_checkpoint_name)
+    for name, tensor in list(module.named_parameters()) + list(module.named_buffers()):
+        if str(tensor.device) != "meta":
+            continue  # already materialized (e.g. shared/tied weights)
+        full_name = f"{module_name}.{name}"
+        if not index.has_tensor(full_name):
+            logger.warning("No checkpoint tensor found for %s, leaving on meta", full_name)
+            continue
+        targets.append((name, full_name))
+
+    if not targets:
+        return
+    values = index.read_tensors([full_name for _, full_name in targets], device=device)
+    for name, full_name in targets:
+        set_module_tensor_to_device(module, name, device, value=values[full_name])
+
+
+def free_module(module: nn.Module) -> None:
+    """Release a module's real tensors back to the meta device, freeing memory."""
+    for name, tensor in list(module.named_parameters()) + list(module.named_buffers()):
+        if str(tensor.device) == "meta":
+            continue
+        set_module_tensor_to_device(module, name, "meta")

--- a/src/reap/layerwise_observer.py
+++ b/src/reap/layerwise_observer.py
@@ -24,6 +24,7 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 from transformers.tokenization_utils_base import BatchEncoding
+from transformers.masking_utils import create_causal_mask
 
 from reap.observer import (
     MoETransformerObserverConfig,
@@ -39,6 +40,7 @@ from reap.layerwise_model_utils import (
 )
 from reap.pruning_metrics import initialize_pruning_state, update_pruning_state
 from reap.metrics import OnlineStatsTracker
+from reap.disk_stream_util import SafetensorsIndex, materialize_module, free_module
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -56,6 +58,15 @@ class ReplayBatch:
     kwargs: Dict[str, Any]
     attention_mask: Optional[torch.Tensor] = None
     position_ids: Optional[torch.Tensor] = None
+    # Local addition: hybrid-attention models (e.g. Qwen3.5's mix of
+    # linear_attention/full_attention layers) compute a *different* mask per layer
+    # type -- `attention_mask` above is whatever mask block 0's own layer_type
+    # received (e.g. the raw/linear mask if block 0 is linear_attention), which is
+    # wrong to replay verbatim into a later full_attention block. `causal_mask` is
+    # the properly-constructed causal mask for full_attention layers, computed once
+    # alongside the rest of block 0's captured inputs; the right one is selected per
+    # block by layer_type at replay time (see _forward_block).
+    causal_mask: Optional[torch.Tensor] = None
 
 
 class ReplayCache:
@@ -73,6 +84,7 @@ class ReplayCache:
         kwargs: Dict[str, Any],
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        causal_mask: Optional[torch.Tensor] = None,
     ) -> None:
         self._batches.append(
             ReplayBatch(
@@ -80,6 +92,7 @@ class ReplayCache:
                 kwargs=kwargs,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
+                causal_mask=causal_mask,
             )
         )
 
@@ -110,6 +123,12 @@ class ReplayCache:
         if batch.position_ids is not None:
             replay_kwargs["position_ids"] = move_to_device(
                 batch.position_ids, target_device
+            )
+        if batch.causal_mask is not None:
+            # Internal-only key, consumed and stripped in _forward_block's per-block
+            # mask selection -- never passed to a block's forward directly.
+            replay_kwargs["_causal_mask"] = move_to_device(
+                batch.causal_mask, target_device
             )
 
         return replay_inputs, replay_kwargs
@@ -158,6 +177,7 @@ class LayerwiseMoEObserver:
         model: nn.Module,
         hook_config: MoETransformerObserverConfig,
         block_names: Optional[List[str]] = None,
+        disk_index: Optional[SafetensorsIndex] = None,
     ):
         """
         Initialize the layerwise (blockwise) MoE observer.
@@ -166,9 +186,17 @@ class LayerwiseMoEObserver:
             model: The PyTorch MoE model to observe
             hook_config: Configuration for hooks (contains MoE-specific settings)
             block_names: List of transformer block names. Auto-detected if None.
+            disk_index: Local addition. When given, blocks with meta-device
+                parameters (i.e. the model was constructed with
+                accelerate.init_empty_weights() rather than fully materialized via
+                device_map="cpu") are streamed in from the checkpoint's safetensors
+                shards on demand -- materialized right before their forward and
+                released back to meta right after -- instead of requiring the whole
+                model resident in RAM up front. See disk_stream_util.py.
         """
         self.model = model
         self.hook_config = hook_config
+        self.disk_index = disk_index
         self._memory_cleanup_freq = 4
 
         # Auto-detect decoder blocks if not provided
@@ -249,6 +277,18 @@ class LayerwiseMoEObserver:
         """
         try:
             if has_meta_tensors(block):
+                if self.disk_index is not None and device != "meta":
+                    # Local addition: this block was constructed on the meta
+                    # device (init_empty_weights) rather than fully materialized
+                    # via device_map="cpu" -- stream its real tensors in from the
+                    # checkpoint directly onto the target device.
+                    materialize_module(
+                        block, self.block_names[block_idx], self.disk_index, device
+                    )
+                    logger.debug(
+                        "Materialized block %s from disk onto %s", block_idx, device
+                    )
+                    return safe_get_device(block)
                 logger.debug(
                     "Block %s has meta tensors, skipping move to %s",
                     block_idx,
@@ -294,16 +334,20 @@ class LayerwiseMoEObserver:
         return final_device
 
     def _offload_current_block(self) -> None:
-        """Offload the current block to CPU and release memory."""
+        """Offload the current block to CPU and release memory. When disk-streaming
+        (see disk_index), offloads all the way to meta instead of cpu, so the real
+        tensors are actually freed rather than accumulating in system RAM -- the
+        block gets re-materialized from disk next time it's needed."""
         block_idx = self.currently_loaded_block_idx
         if block_idx < 0:
             return
 
         block = self._block_at(block_idx)
+        offload_device = "meta" if self.disk_index is not None else "cpu"
 
         try:
             if block is not None:
-                self._move_block(block, block_idx, "cpu")
+                self._move_block(block, block_idx, offload_device)
         finally:
             self.currently_loaded_block_idx = -1
             cleanup_memory(synchronize=False)
@@ -468,6 +512,26 @@ class LayerwiseMoEObserver:
                     continue
                 replay_kwargs[key] = move_to_device(value, cpu_device)
 
+            # Local addition: hybrid-attention models (Qwen3.5) compute a separate
+            # causal mask for full_attention layers, distinct from whatever mask
+            # block 0 (possibly a linear_attention layer) received above. Compute it
+            # the same way the real model forward does, so later full_attention
+            # blocks get the right mask at replay time instead of block 0's.
+            causal_mask = None
+            hidden_states_value = args[0] if args else kwargs.get("hidden_states")
+            if torch.is_tensor(hidden_states_value):
+                try:
+                    text_config = LayerwiseMoEObserver._resolve_text_config(self.model)
+                    causal_mask = create_causal_mask(
+                        config=text_config,
+                        inputs_embeds=hidden_states_value,
+                        attention_mask=attention_mask,
+                        past_key_values=None,
+                        position_ids=position_ids,
+                    )
+                except Exception as exc:
+                    logger.debug("Could not precompute a causal_mask for replay: %s", exc)
+
             captured_batches.append(
                 ReplayBatch(
                     inputs=replay_inputs,
@@ -479,6 +543,9 @@ class LayerwiseMoEObserver:
                     else None,
                     position_ids=position_ids.detach().cpu()
                     if torch.is_tensor(position_ids)
+                    else None,
+                    causal_mask=causal_mask.detach().cpu()
+                    if torch.is_tensor(causal_mask)
                     else None,
                 )
             )
@@ -505,6 +572,7 @@ class LayerwiseMoEObserver:
                 kwargs=batch.kwargs,
                 attention_mask=batch.attention_mask,
                 position_ids=batch.position_ids,
+                causal_mask=batch.causal_mask,
             )
 
         logger.info("Prepared replay cache for %s batches", len(self.replay_cache))
@@ -521,6 +589,15 @@ class LayerwiseMoEObserver:
                 continue
             sanitized[key] = value
         return sanitized
+
+    @staticmethod
+    def _resolve_text_config(model: nn.Module):
+        """Local addition: find the text-only config a decoder layer's masking
+        logic was built against, for models where the top-level config wraps a
+        separate text_config (e.g. multimodal Qwen3.5 wrappers)."""
+        inner = getattr(model, "model", model)
+        text_module = getattr(inner, "language_model", inner)
+        return getattr(text_module, "config", model.config)
 
     def _get_forward_signature_info(self, block_idx: int) -> Tuple[set[str], bool]:
         """Return accepted forward kwargs and whether the block accepts **kwargs."""
@@ -660,8 +737,24 @@ class LayerwiseMoEObserver:
             return router_logits
 
         if self.hook_config.fused_experts:
-            # Fused experts (e.g., Llama-4)
-            router_logits = extract_router_logits(moe_module.router, flat_input)
+            # Fused experts (e.g., Llama-4, Qwen3.5).
+            # Local addition: Qwen3.5's router (`gate`) returns
+            # (router_logits, router_scores, router_indices) -- logits *first*,
+            # unlike REAP's generic extract_router_logits(), which assumes the
+            # logits are the *last* element of a returned tuple. Normalize via a
+            # thin wrapper instead of touching that shared helper (other models
+            # rely on its convention).
+            router_module = getattr(moe_module, "router", None)
+            if router_module is None and hasattr(moe_module, "gate"):
+                gate_module = moe_module.gate
+
+                def router_module(x):
+                    result = gate_module(x)
+                    return result[0] if isinstance(result, tuple) else result
+            if router_module is None:
+                raise ValueError(f"Cannot find router in MoE module at block {block_idx}")
+
+            router_logits = extract_router_logits(router_module, flat_input)
             _, selected_experts = torch.topk(router_logits, top_k, dim=-1)
             selected_experts = selected_experts.to(device)
 
@@ -676,8 +769,26 @@ class LayerwiseMoEObserver:
                 dim=0,
                 index=router_indices,
             ).to(device)
-            routed_out = moe_module.experts(routed_in)
-            activations = routed_out.view(num_experts, *flat_input.shape)
+            try:
+                # Llama4-style fused experts: forward(hidden_states) accepts an
+                # (num_experts * tokens, hidden) tensor directly.
+                routed_out = moe_module.experts(routed_in)
+                activations = routed_out.view(num_experts, *flat_input.shape)
+            except TypeError:
+                # Qwen3.5-style fused experts (Qwen3_5MoeExperts.forward requires
+                # top_k_index/top_k_weights for sparse dispatch -- no dense
+                # all-experts-all-tokens calling convention exists). Compute the
+                # dense (num_experts, tokens, hidden) activations directly from the
+                # raw fused weight tensors instead.
+                experts_module = moe_module.experts
+                gate_up = torch.einsum(
+                    "th,eoh->eto", flat_input, experts_module.gate_up_proj
+                )
+                gate, up = gate_up.chunk(2, dim=-1)
+                hidden = experts_module.act_fn(gate) * up
+                activations = torch.einsum(
+                    "eti,eoi->eto", hidden, experts_module.down_proj
+                )
         else:
             # Loop-based MoE execution
             # First, we need to get router logits by doing a forward pass
@@ -760,6 +871,14 @@ class LayerwiseMoEObserver:
                     batch_idx=batch_idx,
                     target_device=target_device,
                 )
+                # Local addition: hybrid-attention models need a different mask per
+                # layer type (see ReplayBatch.causal_mask) -- swap in the properly
+                # computed causal mask for full_attention blocks; leave whatever
+                # mask was captured (e.g. the raw/linear mask) for everything else.
+                causal_mask = block_kwargs.pop("_causal_mask", None)
+                if causal_mask is not None and getattr(block, "layer_type", None) == "full_attention":
+                    block_kwargs["attention_mask"] = causal_mask
+
                 attention_mask = block_kwargs.get("attention_mask", None)
 
                 block_kwargs = self._build_replay_kwargs(block_idx, block_kwargs)

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -101,6 +101,18 @@ def _load_model_for_layerwise_processing(model_name: str, layerwise_args: "Layer
 
     disk_index = SafetensorsIndex(model_name)
 
+    # Local addition: transformers >=5.10 dispatches the fused-experts forward
+    # to torch._grouped_mm when available, whose meta registration hard-requires
+    # BF16 inputs -- but this layerwise replay runs in float32 (RoPE cos/sin
+    # promote hidden states through the chain). Force the eager per-expert
+    # loop, which is dtype-agnostic; observer throughput is dominated by disk
+    # streaming, not the expert matmul dispatch.
+    for cfg_obj in (model.config, getattr(model.config, "get_text_config", lambda: model.config)()):
+        try:
+            cfg_obj._experts_implementation = "eager"
+        except Exception:
+            pass
+
     text_model = model.model.language_model if hasattr(model.model, "language_model") else model.model
     embed_prefix = (
         "model.language_model.embed_tokens"

--- a/src/reap/layerwise_prune.py
+++ b/src/reap/layerwise_prune.py
@@ -28,8 +28,12 @@ import hashlib
 from typing import Any, Dict, List
 import yaml
 
+import pathlib as _pathlib
+
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, HfArgumentParser
+import transformers
+from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM, HfArgumentParser
+from accelerate import init_empty_weights
 
 from accelerate.utils import set_seed
 
@@ -48,10 +52,64 @@ from reap.model_util import patched_model_map
 from reap.observer import OBSERVER_CONFIG_REGISTRY
 from reap.layerwise_observer import LayerwiseMoEObserver
 from reap.layerwise_model_utils import cleanup_memory
+from reap.disk_stream_util import SafetensorsIndex, materialize_module
 from reap.eval import run_evaluate
 from reap.prune import prune as prune_model
 from reap.prune import get_pruned_model_dir
 from reap.main import dump_args_to_yaml, create_results_directory
+
+
+def _is_local_checkpoint_dir(model_name: str) -> bool:
+    """Local addition: True when model_name is a local directory with a safetensors
+    checkpoint on disk (our disk-streaming path applies here), as opposed to a
+    HuggingFace Hub model id (where the original device_map="cpu" full-RAM load is
+    kept, since REAP's other supported models are small enough for that to be fine)."""
+    path = _pathlib.Path(model_name)
+    return path.is_dir() and (
+        (path / "model.safetensors.index.json").exists()
+        or (path / "model.safetensors").exists()
+    )
+
+
+def _load_model_for_layerwise_processing(model_name: str, layerwise_args: "LayerwiseArgs"):
+    """Local addition: for local checkpoints, build the model on the meta device
+    (accelerate.init_empty_weights(), ~0 RAM) and materialize only the embedding
+    table for real, instead of device_map="cpu" (which materializes the *entire*
+    checkpoint in RAM -- infeasible for models much larger than available RAM+VRAM
+    combined). Each decoder block's real weights are streamed in from disk on
+    demand by LayerwiseMoEObserver (see disk_stream_util.py), one block at a time.
+    Returns (model, disk_index_or_None)."""
+    if not _is_local_checkpoint_dir(model_name):
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            device_map="cpu",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            low_cpu_mem_usage=layerwise_args.low_cpu_mem_usage,
+        )
+        return model, None
+
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    archs = getattr(config, "architectures", None)
+    model_cls = getattr(transformers, archs[0], None) if archs else None
+
+    with init_empty_weights():
+        if model_cls is not None:
+            model = model_cls(config)
+        else:
+            model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+
+    disk_index = SafetensorsIndex(model_name)
+
+    text_model = model.model.language_model if hasattr(model.model, "language_model") else model.model
+    embed_prefix = (
+        "model.language_model.embed_tokens"
+        if hasattr(model.model, "language_model")
+        else "model.embed_tokens"
+    )
+    materialize_module(text_model.embed_tokens, embed_prefix, disk_index, device="cpu")
+
+    return model, disk_index
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -153,6 +211,7 @@ def record_activations_layerwise(
     obs_args: ObserverArgs,
     layerwise_args: LayerwiseArgs,
     results_dir: pathlib.Path,
+    disk_index: "SafetensorsIndex | None" = None,
 ) -> Dict[int, Dict[str, Any]]:
     """
     Record MoE activations using layerwise processing.
@@ -179,6 +238,7 @@ def record_activations_layerwise(
     observer = LayerwiseMoEObserver(
         model=model,
         hook_config=hook_config,
+        disk_index=disk_index,
     )
 
     # Process all blocks
@@ -277,15 +337,11 @@ def main():
         logger.info("Preparing calibration samples...")
         data_batches = prepare_calibration_batches(tokenizer, ds_args, obs_args)
 
-        # Load model on CPU for layerwise processing
-        logger.info(f"Loading model {model_name} on CPU for layerwise processing...")
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            device_map="cpu",
-            torch_dtype="auto",
-            trust_remote_code=True,
-            low_cpu_mem_usage=layerwise_args.low_cpu_mem_usage,
-        )
+        # Load model for layerwise processing (disk-streamed for local checkpoints
+        # too large to fit in RAM; device_map="cpu" full load otherwise -- see
+        # _load_model_for_layerwise_processing)
+        logger.info(f"Loading model {model_name} for layerwise processing...")
+        model, disk_index = _load_model_for_layerwise_processing(model_name, layerwise_args)
         model.eval()
 
         logger.info(f"Model loaded: {model.__class__.__name__}")
@@ -307,6 +363,7 @@ def main():
                 obs_args,
                 layerwise_args,
                 results_dir,
+                disk_index=disk_index,
             )
 
     if reap_args.run_observer_only:

--- a/src/reap/model_util.py
+++ b/src/reap/model_util.py
@@ -115,12 +115,33 @@ MODEL_ATTRS = {
         "num_experts": "n_routed_experts",
         "num_experts_per_tok": "num_experts_per_tok",
     },
+    # Local addition: not yet in upstream REAP. Qwen3_5MoeExperts stores experts as
+    # fused 3D parameter tensors (gate_up_proj, down_proj), same shape as Llama4's
+    # fused MoE layer above -- reuses that code path via fused=True. shared_expert is
+    # a separate always-on MLP outside this registry and is untouched by pruning.
+    "Qwen3_5MoeForConditionalGeneration": {
+        "moe_block": "mlp",
+        "gate_proj": "gate_up_proj",
+        "up_proj": "gate_up_proj",
+        "down_proj": "down_proj",
+        "experts": "experts",
+        "fused": True,
+        "router": "gate",
+        "num_experts": "num_experts",
+        "num_experts_per_tok": "num_experts_per_tok",
+    },
 }
 
 
 def get_moe(model, layer):
     moe_attr_name = MODEL_ATTRS.get(model.__class__.__name__)["moe_block"]
-    return getattr(model.model.layers[layer], moe_attr_name)
+    # Local addition: Qwen3_5MoeForConditionalGeneration nests decoder layers one
+    # level deeper (model.model.language_model.layers) than the causal-LM-only
+    # classes this originally targeted (model.model.layers).
+    decoder = model.model
+    if hasattr(decoder, "language_model"):
+        decoder = decoder.language_model
+    return getattr(decoder.layers[layer], moe_attr_name)
 
 
 def assert_merge(model, merged_moe, cluster_label):

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -524,6 +524,18 @@ class Glm44MoEObserverHookConfig(MoETransformerObserverConfig):
     fused_experts: bool = False
 
 
+# Local addition: not yet in upstream REAP, mirrors Llama4MoEObserverHookConfig
+# since Qwen3_5MoeExperts is likewise fused (see model_util.py's MODEL_ATTRS patch).
+# Qwen3_5MoeSparseMoeBlock itself has no num_experts/top_k attrs -- they live on its
+# .experts and .gate submodules respectively.
+@dataclass
+class Qwen3_5MoEObserverHookConfig(MoETransformerObserverConfig):
+    module_class_name_to_hook_regex: Optional[str] = "Qwen3_5MoeSparseMoeBlock"
+    num_experts_attr_name: str = "experts.num_experts"
+    top_k_attr_name: str = "gate.top_k"
+    fused_experts: bool = True
+
+
 OBSERVER_CONFIG_REGISTRY = {
     "Qwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
     "NonUniformQwen3MoeForCausalLM": Qwen3MoEObserverHookConfig,
@@ -533,4 +545,6 @@ OBSERVER_CONFIG_REGISTRY = {
     "Ernie4_5_MoEForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Ernie4_5_MoeForCausalLM": Ernie4_5MoEObserverHookConfig,
     "Glm4MoeForCausalLM": Glm44MoEObserverHookConfig,
+    "Qwen3_5MoeForConditionalGeneration": Qwen3_5MoEObserverHookConfig,
+    "Qwen3_5MoeForCausalLM": Qwen3_5MoEObserverHookConfig,
 }

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -40,6 +40,40 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+# Local addition: extracted from prune()'s inline body so it's reusable without an
+# already-loaded model -- el_prune_disk_surgery.py calls this directly to compute
+# retained expert indices per layer, then does its own disk-native tensor surgery
+# (no in-memory model instantiation) rather than going through prune()'s
+# in-memory model mutation + save_pretrained path below.
+def select_retained_experts(
+    observer_data, layer, prune_args, n_experts_to_prune, device="cpu"
+) -> list[int]:
+    """Return the sorted list of expert indices to KEEP for one layer, using the
+    same saliency criterion / top-k-least-salient selection as prune()."""
+    num_experts = observer_data[layer]["expert_frequency"].shape[0]
+    if prune_args.prune_method == "ean_ca":
+        ean = torch.zeros(num_experts, device=device, dtype=torch.float32)
+        for i in range(num_experts):
+            ean[i] = torch.linalg.norm(
+                observer_data[layer]["routed_characteristic_activation"][i], dim=-1
+            ).sum()
+        _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
+    else:
+        prune_method = prune_args.prune_method
+        if prune_method == "frequency":
+            prune_method = "expert_frequency"
+        saliency_data = observer_data[layer].get(prune_method)
+        if saliency_data is None:
+            raise ValueError(
+                f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
+                f"Available keys: {list(observer_data[layer].keys())}"
+            )
+        _, experts_to_prune = torch.topk(saliency_data, n_experts_to_prune, largest=False)
+
+    experts_to_prune = set(experts_to_prune.tolist())
+    return [i for i in range(num_experts) if i not in experts_to_prune]
+
+
 def prune(
     observer_data,
     model,
@@ -80,31 +114,10 @@ def prune(
                         observer_data[layer][metric][super_experts_in_layer] = float("inf")
 
     for layer in tqdm(observer_data, "Pruning layers..."):
-        num_experts = observer_data[layer]["expert_frequency"].shape[0]
-        if prune_args.prune_method == "ean_ca":
-            ean = torch.zeros(num_experts, device=model.device, dtype=torch.float32)
-            for i in range(num_experts):
-                ean[i] = torch.linalg.norm(
-                    observer_data[layer]["routed_characteristic_activation"][i], dim=-1
-                ).sum()
-            _, experts_to_prune = torch.topk(ean, n_experts_to_prune, largest=False)
-        else:
-            prune_method = prune_args.prune_method
-            if prune_method == "frequency":
-                prune_method = "expert_frequency"
-            saliency_data = observer_data[layer].get(prune_method)
-            if saliency_data is None:
-                raise ValueError(
-                    f"Prune method {prune_args.prune_method} not found in observer data for layer {layer}. "
-                    f"Available keys: {list(observer_data[layer].keys())}"
-                )
-            _, experts_to_prune = torch.topk(
-                saliency_data, n_experts_to_prune, largest=False
-            )
-
-        retained_expert_indicies = [
-            i for i in range(num_experts) if i not in experts_to_prune
-        ]
+        retained_expert_indicies = select_retained_experts(
+            observer_data, layer, prune_args, n_experts_to_prune,
+            device=model.device,
+        )
         # prune experts
         moe = get_moe(model, layer)
         if not model_attrs["fused"]:
@@ -133,16 +146,26 @@ def prune(
                 )
             setattr(moe, model_attrs["router"], router)
         else:
-            # prune fused experts, only tested for llama-4
+            # prune fused experts. Originally only tested for llama-4 (hardcoded
+            # `moe.router`, assumed nn.Linear with `out_features`); generalized here
+            # to go through model_attrs["router"] and to tolerate routers that are
+            # raw weight Parameters without `out_features` (e.g. Qwen3.5's
+            # Qwen3_5MoeTopKRouter).
             moe.experts.gate_up_proj.data = moe.experts.gate_up_proj[
                 retained_expert_indicies
             ]
             moe.experts.down_proj.data = moe.experts.down_proj[retained_expert_indicies]
-            moe.num_experts = len(retained_expert_indicies)
-            moe.router.weight.data = moe.router.weight.data[retained_expert_indicies]
-            moe.router.out_features = len(retained_expert_indicies)
-            if hasattr(moe.router, "num_experts"):  # transformers >= 4.54+
-                moe.router.num_experts = len(retained_expert_indicies)
+            if hasattr(moe.experts, "num_experts"):
+                moe.experts.num_experts = len(retained_expert_indicies)
+            if hasattr(moe, "num_experts"):
+                moe.num_experts = len(retained_expert_indicies)
+            router = getattr(moe, model_attrs["router"])
+            router.weight.data = router.weight.data[retained_expert_indicies]
+            if hasattr(router, "out_features"):
+                router.out_features = len(retained_expert_indicies)
+            if hasattr(router, "num_experts"):  # transformers >= 4.54+
+                router.num_experts = len(retained_expert_indicies)
+            setattr(moe, model_attrs["router"], router)
 
     # patch config and dump
     logger.info("Saving pruned model...")


### PR DESCRIPTION
## Summary

Depends on #26 (disk-streaming) — stacked on top of it, so the diff includes those commits until it merges; only the last commit is new here.

Recent `transformers` versions dispatch the fused-experts forward to `torch._grouped_mm` when available, whose meta registration hard-requires BF16 inputs — but this layerwise replay runs in float32 (RoPE cos/sin promote hidden states through the chain), which crashes. Forces the eager per-expert loop instead, which is dtype-agnostic; observer throughput here is dominated by disk streaming, not the expert matmul dispatch, so this has no meaningful performance cost.